### PR TITLE
Patch for eventual merge with OBA-app-mods trunk for OBA-NYC

### DIFF
--- a/onebusaway-api-core/pom.xml
+++ b/onebusaway-api-core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-application-modules</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.19-SNAPSHOT</version>
   </parent>
   <artifactId>onebusaway-api-core</artifactId>
 

--- a/onebusaway-api-webapp/pom.xml
+++ b/onebusaway-api-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-application-modules</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.19-SNAPSHOT</version>
   </parent>
   <artifactId>onebusaway-api-webapp</artifactId>
   <packaging>war</packaging>

--- a/onebusaway-combined-webapp/pom.xml
+++ b/onebusaway-combined-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-application-modules</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.19-SNAPSHOT</version>
   </parent>
   <artifactId>onebusaway-combined-webapp</artifactId>
   <packaging>pom</packaging>

--- a/onebusaway-container/pom.xml
+++ b/onebusaway-container/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.onebusaway</groupId>
         <artifactId>onebusaway-application-modules</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-container</artifactId>
     <packaging>jar</packaging>

--- a/onebusaway-core/pom.xml
+++ b/onebusaway-core/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.onebusaway</groupId>
         <artifactId>onebusaway-application-modules</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-core</artifactId>
     <packaging>jar</packaging>

--- a/onebusaway-federations-webapp/pom.xml
+++ b/onebusaway-federations-webapp/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>onebusaway-application-modules</artifactId>
         <groupId>org.onebusaway</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-federations-webapp</artifactId>
     <packaging>war</packaging>

--- a/onebusaway-federations/pom.xml
+++ b/onebusaway-federations/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.onebusaway</groupId>
         <artifactId>onebusaway-application-modules</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-federations</artifactId>
     <packaging>jar</packaging>

--- a/onebusaway-geocoder/pom.xml
+++ b/onebusaway-geocoder/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>onebusaway-application-modules</artifactId>
         <groupId>org.onebusaway</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-geocoder</artifactId>
 

--- a/onebusaway-geospatial/pom.xml
+++ b/onebusaway-geospatial/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>onebusaway-application-modules</artifactId>
         <groupId>org.onebusaway</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-geospatial</artifactId>
 

--- a/onebusaway-gtfs-hibernate-spring/pom.xml
+++ b/onebusaway-gtfs-hibernate-spring/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <artifactId>onebusaway-application-modules</artifactId>
     <groupId>org.onebusaway</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.19-SNAPSHOT</version>
   </parent>
 
   <dependencies>

--- a/onebusaway-phone-webapp/pom.xml
+++ b/onebusaway-phone-webapp/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>onebusaway-application-modules</artifactId>
         <groupId>org.onebusaway</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-phone-webapp</artifactId>
     <packaging>war</packaging>

--- a/onebusaway-phone/pom.xml
+++ b/onebusaway-phone/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.onebusaway</groupId>
         <artifactId>onebusaway-application-modules</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-phone</artifactId>
     <packaging>jar</packaging>

--- a/onebusaway-presentation/pom.xml
+++ b/onebusaway-presentation/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.onebusaway</groupId>
         <artifactId>onebusaway-application-modules</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-presentation</artifactId>
     <packaging>jar</packaging>

--- a/onebusaway-realtime-api/pom.xml
+++ b/onebusaway-realtime-api/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.onebusaway</groupId>
         <artifactId>onebusaway-application-modules</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-realtime-api</artifactId>
     <packaging>jar</packaging>

--- a/onebusaway-sms-webapp/pom.xml
+++ b/onebusaway-sms-webapp/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>onebusaway-application-modules</artifactId>
         <groupId>org.onebusaway</groupId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
 
     <artifactId>onebusaway-sms-webapp</artifactId>

--- a/onebusaway-transit-data-federation-builder/pom.xml
+++ b/onebusaway-transit-data-federation-builder/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>onebusaway-application-modules</artifactId>
     <groupId>org.onebusaway</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.19-SNAPSHOT</version>
   </parent>
   <artifactId>onebusaway-transit-data-federation-builder</artifactId>
 

--- a/onebusaway-transit-data-federation-webapp/pom.xml
+++ b/onebusaway-transit-data-federation-webapp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-application-modules</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.19-SNAPSHOT</version>
   </parent>
   <artifactId>onebusaway-transit-data-federation-webapp</artifactId>
   <packaging>war</packaging>

--- a/onebusaway-transit-data-federation/pom.xml
+++ b/onebusaway-transit-data-federation/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-application-modules</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.19-SNAPSHOT</version>
   </parent>
   <artifactId>onebusaway-transit-data-federation</artifactId>
   <packaging>jar</packaging>

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/ExtendedCalendarServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/ExtendedCalendarServiceImpl.java
@@ -34,6 +34,7 @@ import net.sf.ehcache.Element;
 
 import org.onebusaway.collections.CollectionsLibrary;
 import org.onebusaway.container.cache.Cacheable;
+import org.onebusaway.container.refresh.Refreshable;
 import org.onebusaway.gtfs.model.calendar.LocalizedServiceId;
 import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.onebusaway.gtfs.model.calendar.ServiceInterval;
@@ -90,6 +91,7 @@ public class ExtendedCalendarServiceImpl implements ExtendedCalendarService {
   }
 
   @PostConstruct
+  @Refreshable(dependsOn = RefreshableResources.CALENDAR_DATA)
   public void start() {
     cacheServiceDatesForServiceIds();
   }
@@ -404,6 +406,12 @@ public class ExtendedCalendarServiceImpl implements ExtendedCalendarService {
 
   private void cacheServiceDatesForServiceIds() {
 
+    if(_serviceDateRangeCache != null) {
+      _serviceDateRangeCache.removeAll();
+    }
+    
+    _serviceDatesByServiceIds.clear();
+    
     Set<ServiceIdActivation> allServiceIds = determineAllServiceIds();
 
     Date lowerBounds = null;

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/RefreshableResources.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/RefreshableResources.java
@@ -34,7 +34,9 @@ public final class RefreshableResources {
   public static final String BLOCK_INDEX_SERVICE = "blockIndexService";
 
   public static final String STOP_TRANSFER_DATA = "stopTransferData";
-  
+
+  public static final String STOP_GEOSPATIAL_INDEX = "stopGeospatialIndex";
+
   public static final String SHAPE_GEOSPATIAL_INDEX = "shapeGeospatialIndex";
   
   public static final String TRANSFER_PATTERNS = "transfer_patterns";

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/ServiceAlertsBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/ServiceAlertsBeanServiceImpl.java
@@ -26,6 +26,7 @@ import org.onebusaway.transit_data.model.service_alerts.NaturalLanguageStringBea
 import org.onebusaway.transit_data.model.service_alerts.ServiceAlertBean;
 import org.onebusaway.transit_data.model.service_alerts.SituationAffectsBean;
 import org.onebusaway.transit_data.model.service_alerts.SituationConsequenceBean;
+import org.onebusaway.transit_data.model.service_alerts.SituationQueryBean;
 import org.onebusaway.transit_data.model.service_alerts.TimeRangeBean;
 import org.onebusaway.transit_data_federation.impl.service_alerts.ServiceAlertLibrary;
 import org.onebusaway.transit_data_federation.services.AgencyAndIdLibrary;
@@ -130,6 +131,12 @@ class ServiceAlertsBeanServiceImpl implements ServiceAlertsBeanService {
     List<ServiceAlert> serviceAlerts = _serviceAlertsService.getServiceAlertsForVehicleJourney(
         time, blockTripInstance, vehicleId);
 
+    return list(serviceAlerts);
+  }
+
+  @Override
+  public List<ServiceAlertBean> getServiceAlerts(SituationQueryBean query) {
+    List<ServiceAlert> serviceAlerts = _serviceAlertsService.getServiceAlerts(query);
     return list(serviceAlerts);
   }
 
@@ -417,4 +424,5 @@ class ServiceAlertsBeanServiceImpl implements ServiceAlertsBeanService {
 
     return nlsBeans;
   }
+
 }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/VehicleStatusBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/VehicleStatusBeanServiceImpl.java
@@ -40,11 +40,15 @@ import org.onebusaway.transit_data_federation.services.realtime.BlockLocation;
 import org.onebusaway.transit_data_federation.services.realtime.BlockLocationService;
 import org.onebusaway.transit_data_federation.services.realtime.VehicleStatus;
 import org.onebusaway.transit_data_federation.services.realtime.VehicleStatusService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 class VehicleStatusBeanServiceImpl implements VehicleStatusBeanService {
+
+  private static Logger _log = LoggerFactory.getLogger(VehicleStatusBeanServiceImpl.class);
 
   private VehicleStatusService _vehicleStatusService;
 
@@ -79,6 +83,12 @@ class VehicleStatusBeanServiceImpl implements VehicleStatusBeanService {
     _vehicleLocationListener = vehicleLocationListener;
   }
 
+  @Autowired
+  public void setBlockLocationService(
+      BlockLocationService blockLocationService) {
+      _blockLocationService = blockLocationService;
+  }
+
   public VehicleStatusBean getVehicleForId(AgencyAndId vehicleId, long time) {
     VehicleStatus status = _vehicleStatusService.getVehicleStatusForId(vehicleId);
     if (status == null)
@@ -111,6 +121,11 @@ class VehicleStatusBeanServiceImpl implements VehicleStatusBeanService {
       AgencyAndId vehicleId, long targetTime) {
 
     TargetTime target = new TargetTime(targetTime, targetTime);
+
+    if (_blockLocationService == null) {
+	_log.error("blocklocationservice is null");
+	return null;
+    }
 
     BlockLocation blockLocation = _blockLocationService.getLocationForVehicleAndTime(
         vehicleId, target);

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockGeospatialServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockGeospatialServiceImpl.java
@@ -133,7 +133,9 @@ class BlockGeospatialServiceImpl implements BlockGeospatialService {
       RefreshableResources.SHAPE_GEOSPATIAL_INDEX,
       RefreshableResources.BLOCK_INDEX_SERVICE})
   public void setup() throws IOException, ClassNotFoundException {
+    _blockSequenceIndicesByShapeId.clear();
     groupBlockSequenceIndicesByShapeIds();
+
     buildShapeSpatialIndex();
   }
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockStatusServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockStatusServiceImpl.java
@@ -49,12 +49,12 @@ public class BlockStatusServiceImpl implements BlockStatusService {
   /**
    * Catch late trips up to 30 minutes
    */
-  private static final long TIME_BEFORE_WINDOW = 30 * 60 * 1000;
+  private static final long TIME_BEFORE_WINDOW = 90 * 60 * 1000;
 
   /**
    * Catch early blocks up to 10 minutes
    */
-  private static final long TIME_AFTER_WINDOW = 10 * 60 * 1000;
+  private static final long TIME_AFTER_WINDOW = 90 * 60 * 1000;
 
   private BlockCalendarService _blockCalendarService;
 
@@ -133,8 +133,11 @@ public class BlockStatusServiceImpl implements BlockStatusService {
   @Override
   public List<BlockLocation> getBlocksForRoute(AgencyAndId routeId, long time) {
 
+    long timeFrom = time - TIME_BEFORE_WINDOW;
+    long timeTo = time + TIME_AFTER_WINDOW;
+
     List<BlockInstance> instances = _blockCalendarService.getActiveBlocksForRouteInTimeRange(
-        routeId, time, time);
+        routeId, timeFrom, timeTo);
 
     return getAsLocations(instances, time);
   }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/federated/TransitDataServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/federated/TransitDataServiceImpl.java
@@ -545,7 +545,7 @@ class TransitDataServiceImpl implements TransitDataService {
           query.getTime(), stopIds);
       return new ListBean<ServiceAlertBean>(situations, false);
     } else {
-      List<ServiceAlertBean> situations = _serviceAlertsBeanService.getServiceAlertsForFederatedAgencyId(query.getAgencyId());
+      List<ServiceAlertBean> situations = _serviceAlertsBeanService.getServiceAlerts(query);
       return new ListBean<ServiceAlertBean>(situations, false);
     }
   }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/VehicleStatusServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/VehicleStatusServiceImpl.java
@@ -92,6 +92,13 @@ class VehicleStatusServiceImpl implements VehicleLocationListener,
     // TODO : Maybe not require service date?
     if (blockId != null && record.getServiceDate() != 0)
       _blockVehicleLocationService.handleVehicleLocationRecord(record);
+
+    // if vehicle has no block or has lost it, remove it from the block VLS.
+    else {
+      if(record.getVehicleId() != null) {
+        _blockVehicleLocationService.resetVehicleLocation(record.getVehicleId());
+      }
+    }
   }
 
   @Override

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/siri/SiriService.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/siri/SiriService.java
@@ -437,7 +437,7 @@ public class SiriService {
    * Affects
    ****/
 
-  private void handleAffects(PtSituationElementStructure ptSituation,
+  protected void handleAffects(PtSituationElementStructure ptSituation,
       ServiceAlert.Builder serviceAlert) {
 
     AffectsScopeStructure affectsStructure = ptSituation.getAffects();

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/TransitGraphDaoImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/TransitGraphDaoImpl.java
@@ -61,6 +61,13 @@ public class TransitGraphDaoImpl implements TransitGraphDao {
   @Refreshable(dependsOn = RefreshableResources.TRANSIT_GRAPH)
   public void setup() throws IOException, ClassNotFoundException {
     File path = _bundle.getTransitGraphPath();
+
+    if(_graph != null) {
+      TransitGraphImpl graph = (TransitGraphImpl)_graph;
+      graph.empty();
+      _graph = null;
+    }
+    
     if (path.exists()) {
       TransitGraphImpl graph = ObjectSerializationLibrary.readObject(path);
       graph.initialize();

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/TransitGraphImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/TransitGraphImpl.java
@@ -95,6 +95,24 @@ public class TransitGraphImpl implements Serializable, TripPlannerGraph {
 
   }
 
+  public void empty() {
+    _agencyEntriesById.clear();
+    _stopEntriesById.clear();
+    _tripEntriesById.clear();
+    _blockEntriesById.clear();
+    _routeCollectionEntriesById.clear();
+    _routeEntriesById.clear();
+    
+    _routeCollections.clear();
+    _blocks.clear();
+    _trips.clear();
+    _stops.clear();
+    _routes.clear();
+    _agencies.clear();
+
+    _stopLocationTree = null;        
+  }
+  
   public void initialize() {
     if (_stopLocationTree == null) {
       System.out.println("initializing trip planner graph...");

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/beans/ServiceAlertsBeanService.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/beans/ServiceAlertsBeanService.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.transit_data.model.service_alerts.ServiceAlertBean;
+import org.onebusaway.transit_data.model.service_alerts.SituationQueryBean;
 import org.onebusaway.transit_data_federation.services.blocks.BlockInstance;
 import org.onebusaway.transit_data_federation.services.blocks.BlockTripInstance;
 import org.onebusaway.transit_data_federation.services.transit_graph.BlockStopTimeEntry;
@@ -45,6 +46,8 @@ public interface ServiceAlertsBeanService {
 
   public List<ServiceAlertBean> getServiceAlertsForStopIds(long time,
       Iterable<AgencyAndId> stopIds);
+
+  public List<ServiceAlertBean> getServiceAlerts(SituationQueryBean query);
 
   public List<ServiceAlertBean> getServiceAlertsForStopCall(long time,
       BlockInstance blockInstance, BlockStopTimeEntry blockStopTime,

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/service_alerts/ServiceAlertsService.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/service_alerts/ServiceAlertsService.java
@@ -19,6 +19,7 @@ package org.onebusaway.transit_data_federation.services.service_alerts;
 import java.util.List;
 
 import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.transit_data.model.service_alerts.SituationQueryBean;
 import org.onebusaway.transit_data.services.TransitDataService;
 import org.onebusaway.transit_data_federation.services.blocks.BlockInstance;
 import org.onebusaway.transit_data_federation.services.blocks.BlockTripInstance;
@@ -100,5 +101,15 @@ public interface ServiceAlertsService {
   public List<ServiceAlert> getServiceAlertsForVehicleJourney(long time,
       BlockTripInstance blockTripInstance,
       AgencyAndId vehicleId);
+
+  public List<ServiceAlert> getServiceAlerts(SituationQueryBean query);
+
+  /**
+   * Set whether the ServiceAlerts service is responsible for persisting service alerts
+   * across application restarts, or whether an external service will handle that.
+   * 
+   * @param persist
+   */
+  public void doPersistence(boolean persist);
 
 }

--- a/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/impl/service_alerts/ServiceAlertsServiceImplTest.java
+++ b/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/impl/service_alerts/ServiceAlertsServiceImplTest.java
@@ -78,6 +78,8 @@ public class ServiceAlertsServiceImplTest {
 
   @Test
   public void testSerialization() throws IOException {
+    _service.doPersistence(true);
+    
     ServiceAlert.Builder builder = ServiceAlert.newBuilder();
     ServiceAlert serviceAlert = _service.createOrUpdateServiceAlert(builder,
         "1");
@@ -91,6 +93,8 @@ public class ServiceAlertsServiceImplTest {
     assertEquals(serviceAlert.getId().getAgencyId(), read.getId().getAgencyId());
     assertEquals(serviceAlert.getId().getId(), read.getId().getId());
     assertEquals(serviceAlert.getCreationTime(), read.getCreationTime());
+    
+    _service.doPersistence(false);
   }
 
   @Test

--- a/onebusaway-transit-data/pom.xml
+++ b/onebusaway-transit-data/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.onebusaway</groupId>
         <artifactId>onebusaway-application-modules</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <artifactId>onebusaway-transit-data</artifactId>
     <packaging>jar</packaging>

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/SearchQueryBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/SearchQueryBean.java
@@ -35,6 +35,9 @@ public class SearchQueryBean implements Serializable {
   private String query;
 
   private int maxCount;
+  
+  // default minimum lucene result score to keep
+  private double minScoreToKeep = 1.0;
 
   public EQueryType getType() {
     return type;
@@ -66,5 +69,13 @@ public class SearchQueryBean implements Serializable {
 
   public void setMaxCount(int maxCount) {
     this.maxCount = maxCount;
+  }
+
+  public double getMinScoreToKeep() {
+    return minScoreToKeep;
+  }
+
+  public void setMinScoreToKeep(double minScoreToKeep) {
+    this.minScoreToKeep = minScoreToKeep;
   }
 }

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/service_alerts/SituationQueryBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/service_alerts/SituationQueryBean.java
@@ -1,21 +1,22 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
  * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
  */
 package org.onebusaway.transit_data.model.service_alerts;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.onebusaway.transit_data.model.QueryBean;
@@ -25,11 +26,20 @@ public class SituationQueryBean implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
+  // Not clear whether this is service alert agency ID or affects agency ID.
+  // Treating it as latter for now.
   private String agencyId;
 
   private List<String> stopIds;
 
+  // Asked Brian about time in developer list, he said:
+  // "Generally, I'd set it to now(). You can use it to query what service
+  // ids were active at some point in the past or future by changing the
+  // time value."
+  // http://groups.google.com/group/onebusaway-developers/msg/fb9b44cd9ba7bef4?hl=en
   private long time;
+
+  private List<RouteIdAndDirection> routes = new ArrayList<RouteIdAndDirection>();
 
   public String getAgencyId() {
     return agencyId;
@@ -54,4 +64,27 @@ public class SituationQueryBean implements Serializable {
   public void setTime(long time) {
     this.time = time;
   }
+
+  public List<RouteIdAndDirection> getRoutes() {
+    return this.routes;
+  }
+
+  public void setRoutes(List<RouteIdAndDirection> routes) {
+    this.routes = routes;
+  }
+
+  public void addRoute(String id, String direction) {
+    routes.add(new RouteIdAndDirection(id, direction));
+  }
+  
+  public class RouteIdAndDirection implements Serializable {
+    private static final long serialVersionUID = 1L;
+    public RouteIdAndDirection(String routeId, String direction) {
+      this.routeId = routeId;
+      this.direction = direction;
+    }
+    public String routeId;
+    public String direction;
+  }
+
 }

--- a/onebusaway-users/pom.xml
+++ b/onebusaway-users/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.onebusaway</groupId>
         <artifactId>onebusaway-application-modules</artifactId>
-        <version>1.0.2-SNAPSHOT</version>
+        <version>2.0.19-SNAPSHOT</version>
     </parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-users</artifactId>

--- a/onebusaway-webapp/pom.xml
+++ b/onebusaway-webapp/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.onebusaway</groupId>
     <artifactId>onebusaway-application-modules</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>2.0.19-SNAPSHOT</version>
   </parent>
   <artifactId>onebusaway-webapp</artifactId>
   <packaging>war</packaging>
@@ -207,11 +207,13 @@
         <artifactId>gwt-maven-plugin</artifactId>
         <configuration>
           <modules>
+<!--
             <module>org.onebusaway.webapp.gwt.BookmarkEditApplication</module>
             <module>org.onebusaway.webapp.gwt.OneBusAwayStandardApplication</module>
             <module>org.onebusaway.webapp.gwt.SearchLocationLibrary</module>
             <module>org.onebusaway.webapp.gwt.WhereStopFinderRefineViewApplication</module>
             <module>org.onebusaway.webapp.gwt.WhereStopFinderStandardApplication</module>
+-->
           </modules>
           <gwtVersion>${gwt-version}</gwtVersion>
           <webappDirectory>${project.build.directory}/gwt</webappDirectory>
@@ -258,14 +260,17 @@
         <artifactId>maven-war-plugin</artifactId>
         <configuration>
           <webResources>
+<!--
             <resource>
               <directory>target/gwt/org.onebusaway.webapp.gwt.BookmarkEditApplication</directory>
               <targetPath>where/standard</targetPath>
             </resource>
+-->
 <!--             <resource> -->
 <!--               <directory>${project.build.directory}/gwt/LoginWidget</directory> -->
 <!--               <targetPath /> -->
 <!--             </resource> -->
+<!--
             <resource>
               <directory>target/gwt/org.onebusaway.webapp.gwt.OneBusAwayStandardApplication</directory>
               <targetPath>explore/onebusaway</targetPath>
@@ -282,6 +287,7 @@
               <directory>target/gwt/org.onebusaway.webapp.gwt.WhereStopFinderStandardApplication</directory>
               <targetPath>where/standard</targetPath>
             </resource>
+-->
           </webResources>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>onebusaway-application-modules</artifactId>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>2.0.19-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>onebusaway-application-modules</name>


### PR DESCRIPTION
Repasting the developer list post here--to get the conversation started--

Hello OBA-ers,

Brian--this is mostly directed to you: I'm writing to submit a series
of smallish patches we made as part of OBA's integration with MTA Bus
Time to OBA trunk, hopefully to eventually merge these two codebases
back together. Patch is attached. I'm also happy to commit these if I
receive the go-ahead, otherwise feel free to merge them yourself.

Rough summary of patch contents are:

ServiceAlertsServiceImplTest: unit test for service alert changes

RoutesBeanServiceImpl: change to eliminate internal cached data
structures in favor of a "cacheable" method that does the same;
queryBean configurable minimum lucene score to keep

VehicleStatusBeanServiceImpl: informative debugging message only

RefreshableResources: new refreshable resource key for
WhereGeospatialServiceImpl

SiriService: change to enable unit testing

VehicleStatusServiceImpl: change to reset block state in
BlockVehicleLocationService if a record is received by the
VehicleStatusServiceImpl that has no trip/block assigned to it (e.g.
inference drops out) for the same vehicle ID

WhereGeospatialServiceImpl: made "refreshable", plus informative debug message

ServiceAlertsServiceImpl: switch to turn bundle persistence of service
alerts on/off; new time parameter to getServiceAlertIdsAsObject

BlockStatusServiceImpl: enlargement of search window for block list
that backs getBlocksForRoute(), to better handle vehicles assigned to
"late" trips (that weren't within the previously super tight bound
(instant?) specified as "time").

BlockGeospatialServiceImpl: change made to, when "refreshed", clear
the blockSequenceIndices so the old ones are not left in the internal
cache state.

ServiceAreaServiceImpl: turn off
_calculateDefaultBoundsFromAgencyCoverage by default because the call
was failing when required to start the TDS webapp; TDS service was
calling itself, and could not start until itself was available (if
that makes sense).

SearchQueryBean: moved minimum lucene score to keep to this bean so
that it is configurable per query by the developer.

Again, patch is attached for your review/acceptance.

Thanks--let me know what you think, or fire questions my way for
forwarding on to any other relevant team members--

-Jeff
