### PR TITLE
Accept GTFS-realtime trip updates which have a route ID set along with a trip ID

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
@@ -274,7 +274,7 @@ class GtfsRealtimeTripLibrary {
 
   private BlockDescriptor getTripDescriptorAsBlockDescriptor(
       TripDescriptor trip, boolean includeVehicleIds) {
-    if (!trip.hasTripId() || trip.hasRouteId()) {
+    if (!trip.hasTripId()) {
       return null;
     }
     TripEntry tripEntry = _entitySource.getTrip(trip.getTripId());


### PR DESCRIPTION
As long as an update has a trip ID set, it should not be rejected by OBA.  This resolves issues seen in the wild with the GTFS-realtime feed from the AMT and other agencies.

This was previously discussed on the mailing list, and the patch in this pull request was found to resolve the problem.  I don't know why the condition was originally written as (!trip.hasTripId() || trip.hasRouteId()), so it is possible that this could somehow break things, but in my cursory examination I don't see how.

https://groups.google.com/d/topic/onebusaway-users/3tUHwRKFpb0/discussion
