### PR TITLE
Fix handling of GTFS-realtime StopTimeUpdates with absolute times

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
@@ -189,7 +189,7 @@ class GtfsRealtimeTripLibrary {
     for (FeedEntity entity : tripUpdates.getEntityList()) {
       TripUpdate tripUpdate = entity.getTripUpdate();
       if (tripUpdate == null) {
-        _log.warn("epxected a FeedEntity with a TripUpdate");
+        _log.warn("expected a FeedEntity with a TripUpdate");
         continue;
       }
       TripDescriptor trip = tripUpdate.getTrip();
@@ -253,7 +253,7 @@ class GtfsRealtimeTripLibrary {
     for (FeedEntity entity : vehiclePositions.getEntityList()) {
       VehiclePosition vehiclePosition = entity.getVehicle();
       if (vehiclePosition == null) {
-        _log.warn("epxected a FeedEntity with a VehiclePosition");
+        _log.warn("expected a FeedEntity with a VehiclePosition");
         continue;
       }
       if (!(vehiclePosition.hasTrip() || vehiclePosition.hasPosition())) {


### PR DESCRIPTION
GTFS-realtime StopTimeUpdate messages can include either a relative delay or an absolute time.  Both cases are already handled properly in `GtfsRealtimeTripLibrary.getTimeForStopTimeUpdate()`.  However, StopTimeUpdates with absolute times will never get that far, because `GtfsRealtimeTripLibrary.hasDelayValue()` only recognizes arrival and departure times with the `delay` field populated, not `time`.

I've tested this against the [GTFS-realtime feed](http://www.connexionz.co.nz/public_realtime_data_-_arlington) for [Arlington Transit](http://www.arlingtontransit.com/) (which supplies StopTimeUpdates with `time`) and found it to work well.
