### PR TITLE
Re-apply fix for Eclipse/Maven NPE

### DIFF
--- a/onebusaway-webapp/pom.xml
+++ b/onebusaway-webapp/pom.xml
@@ -241,7 +241,7 @@
             </resource>
             <resource>
               <directory>target/gwt/LoginWidget</directory>
-              <targetPath />
+              <targetPath></targetPath>
             </resource>
             <resource>
               <directory>target/gwt/org.onebusaway.webapp.gwt.OneBusAwayStandardApplication</directory>


### PR DESCRIPTION
This is the same fix as https://github.com/OneBusAway/onebusaway-application-modules/commit/04af93bc2168291a34cbfbf5d48b6426d515812c

But was overwritten by this: https://github.com/OneBusAway/onebusaway-application-modules/commit/3d938b3dc82113f171940938fe0ccd869f49354f

This NPE happened on Juno 64-bit on the Mac as well. But no longer.
