### PR TITLE
Add support for GTFS-realtime export to onebusaway-api-webapp

### DIFF
--- a/onebusaway-api-webapp/pom.xml
+++ b/onebusaway-api-webapp/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.onebusaway</groupId>
@@ -34,6 +35,14 @@
       <artifactId>onebusaway-siri-api</artifactId>
       <version>1.0.0</version>
     </dependency>
+
+    <!-- For GTFS-realtime support -->
+    <dependency>
+      <groupId>org.onebusaway</groupId>
+      <artifactId>onebusaway-gtfs-realtime-api</artifactId>
+      <version>1.1.1</version>
+    </dependency>
+
 
     <!-- RMI-like service for wiring up services between VMs -->
     <dependency>
@@ -78,9 +87,19 @@
       <artifactId>slf4j-log4j12</artifactId>
     </dependency>
 
+<!--     <dependency> -->
+<!--       <groupId>org.slf4j</groupId> -->
+<!--       <artifactId>slf4j-log4j12</artifactId> -->
+<!--       <scope>test</scope> -->
+<!--     </dependency> -->
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/AlertsForAgencyAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/AlertsForAgencyAction.java
@@ -1,0 +1,95 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.actions.api.gtfs_realtime;
+
+import java.util.List;
+
+import org.onebusaway.transit_data.model.ListBean;
+import org.onebusaway.transit_data.model.service_alerts.NaturalLanguageStringBean;
+import org.onebusaway.transit_data.model.service_alerts.ServiceAlertBean;
+import org.onebusaway.transit_data.model.service_alerts.SituationAffectsBean;
+import org.onebusaway.transit_data.model.service_alerts.TimeRangeBean;
+
+import com.google.transit.realtime.GtfsRealtime.Alert;
+import com.google.transit.realtime.GtfsRealtime.EntitySelector;
+import com.google.transit.realtime.GtfsRealtime.FeedEntity;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtime.TimeRange;
+import com.google.transit.realtime.GtfsRealtime.TranslatedString;
+import com.google.transit.realtime.GtfsRealtime.TranslatedString.Translation;
+import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
+
+public class AlertsForAgencyAction extends GtfsRealtimeActionSupport {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  protected void fillFeedMessage(FeedMessage.Builder feed, String agencyId,
+      long timestamp) {
+
+    ListBean<ServiceAlertBean> alerts = _service.getAllServiceAlertsForAgencyId(agencyId);
+
+    for (ServiceAlertBean serviceAlert : alerts.getList()) {
+      FeedEntity.Builder entity = feed.addEntityBuilder();
+      entity.setId(Integer.toString(feed.getEntityCount()));
+      Alert.Builder alert = entity.getAlertBuilder();
+
+      fillTranslations(serviceAlert.getSummaries(),
+          alert.getHeaderTextBuilder());
+      fillTranslations(serviceAlert.getDescriptions(),
+          alert.getDescriptionTextBuilder());
+
+      for (TimeRangeBean range : serviceAlert.getActiveWindows()) {
+        TimeRange.Builder timeRange = alert.addActivePeriodBuilder();
+        if (range.getFrom() != 0) {
+          timeRange.setStart(range.getFrom() / 1000);
+        }
+        if (range.getTo() != 0) {
+          timeRange.setEnd(range.getTo() / 1000);
+        }
+      }
+
+      for (SituationAffectsBean affects : serviceAlert.getAllAffects()) {
+        EntitySelector.Builder entitySelector = alert.addInformedEntityBuilder();
+        if (affects.getAgencyId() != null) {
+          entitySelector.setAgencyId(affects.getAgencyId());
+        }
+        if (affects.getRouteId() != null) {
+          entitySelector.setRouteId(normalizeId(affects.getRouteId()));
+        }
+        if (affects.getTripId() != null) {
+          TripDescriptor.Builder trip = entitySelector.getTripBuilder();
+          trip.setTripId(normalizeId(affects.getTripId()));
+          entitySelector.setTrip(trip);
+        }
+        if (affects.getStopId() != null) {
+          entitySelector.setStopId(normalizeId(affects.getStopId()));
+        }
+      }      
+    }
+  }
+
+  private void fillTranslations(List<NaturalLanguageStringBean> input,
+      TranslatedString.Builder output) {
+    for (NaturalLanguageStringBean nls : input) {
+      Translation.Builder translation = output.addTranslationBuilder();
+      translation.setText(nls.getValue());
+      if (nls.getLang() != null) {
+        translation.setLanguage(nls.getLang());
+      }
+    }
+  }
+}

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/GtfsRealtimeActionSupport.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/GtfsRealtimeActionSupport.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.actions.api.gtfs_realtime;
+
+import java.util.Date;
+
+import org.apache.struts2.rest.DefaultHttpHeaders;
+import org.onebusaway.api.actions.api.ApiActionSupport;
+import org.onebusaway.exceptions.ServiceException;
+import org.onebusaway.transit_data.services.TransitDataService;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.google.transit.realtime.GtfsRealtime.FeedHeader;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtimeConstants;
+import com.opensymphony.xwork2.conversion.annotations.TypeConversion;
+import com.opensymphony.xwork2.validator.annotations.RequiredFieldValidator;
+
+public abstract class GtfsRealtimeActionSupport extends ApiActionSupport {
+
+  private static final long serialVersionUID = 1L;
+
+  private static final int V2 = 2;
+
+  @Autowired
+  protected TransitDataService _service;
+
+  private String _agencyId;
+
+  private long _time;
+
+  private boolean _removeAgencyIds = true;
+
+  public GtfsRealtimeActionSupport() {
+    super(V2);
+  }
+  
+  public void setTransitDataService(TransitDataService service) {
+    _service = service;
+  }
+
+  @RequiredFieldValidator
+  public void setId(String id) {
+    _agencyId = id;
+  }
+
+  public String getId() {
+    return _agencyId;
+  }
+
+  @TypeConversion(converter = "org.onebusaway.presentation.impl.conversion.DateTimeConverter")
+  public void setTime(Date time) {
+    _time = time.getTime();
+  }
+
+  public void setRemoveAgencyIsd(boolean removeAgencyIds) {
+    _removeAgencyIds = removeAgencyIds;
+  }
+
+  public DefaultHttpHeaders show() throws ServiceException {
+    if (!isVersion(V2))
+      return setUnknownVersionResponse();
+
+    if (hasErrors())
+      return setValidationErrorsResponse();
+
+    long time = System.currentTimeMillis();
+    if (_time != 0)
+      time = _time;
+
+    FeedMessage.Builder feed = FeedMessage.newBuilder();
+    FeedHeader.Builder header = feed.getHeaderBuilder();
+    header.setGtfsRealtimeVersion(GtfsRealtimeConstants.VERSION);
+    header.setTimestamp(time / 1000);
+    fillFeedMessage(feed, _agencyId, time);
+    return setOkResponse(feed.build());
+  }
+
+  protected abstract void fillFeedMessage(FeedMessage.Builder feed,
+      String agencyId, long timestamp);
+
+  protected String normalizeId(String id) {
+    if (_removeAgencyIds) {
+      int index = id.indexOf('_');
+      if (index != -1) {
+        id = id.substring(index + 1);
+      }
+    }
+    return id;
+  }
+}

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyAction.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.actions.api.gtfs_realtime;
+
+import org.onebusaway.transit_data.model.ListBean;
+import org.onebusaway.transit_data.model.RouteBean;
+import org.onebusaway.transit_data.model.StopBean;
+import org.onebusaway.transit_data.model.VehicleStatusBean;
+import org.onebusaway.transit_data.model.trips.TripBean;
+import org.onebusaway.transit_data.model.trips.TripStatusBean;
+
+import com.google.transit.realtime.GtfsRealtime.FeedEntity;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
+import com.google.transit.realtime.GtfsRealtime.TripUpdate;
+import com.google.transit.realtime.GtfsRealtime.VehicleDescriptor;
+
+public class TripUpdatesForAgencyAction extends GtfsRealtimeActionSupport {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  protected void fillFeedMessage(FeedMessage.Builder feed, String agencyId,
+      long timestamp) {
+
+    ListBean<VehicleStatusBean> vehicles = _service.getAllVehiclesForAgency(
+        agencyId, timestamp);
+
+    for (VehicleStatusBean vehicle : vehicles.getList()) {
+      TripStatusBean tripStatus = vehicle.getTripStatus();
+      if (tripStatus == null) {
+        continue;
+      }
+      TripBean activeTrip = tripStatus.getActiveTrip();
+      RouteBean route = activeTrip.getRoute();
+
+      FeedEntity.Builder entity = feed.addEntityBuilder();
+      entity.setId(Integer.toString(feed.getEntityCount()));
+      TripUpdate.Builder tripUpdate = entity.getTripUpdateBuilder();
+
+      TripDescriptor.Builder tripDesc = tripUpdate.getTripBuilder();
+      tripDesc.setTripId(normalizeId(activeTrip.getId()));
+      tripDesc.setRouteId(normalizeId(route.getId()));
+
+      VehicleDescriptor.Builder vehicleDesc = tripUpdate.getVehicleBuilder();
+      vehicleDesc.setId(normalizeId(vehicle.getVehicleId()));
+
+      StopBean nextStop = tripStatus.getNextStop();
+      if (nextStop != null) {
+        TripUpdate.StopTimeUpdate.Builder stopTimeUpdate = tripUpdate.addStopTimeUpdateBuilder();
+        stopTimeUpdate.setStopId(normalizeId(nextStop.getId()));
+        TripUpdate.StopTimeEvent.Builder departure = stopTimeUpdate.getDepartureBuilder();
+        departure.setTime(timestamp / 1000 + tripStatus.getNextStopTimeOffset());
+      }
+
+      tripUpdate.setTimestamp(vehicle.getLastUpdateTime() / 1000);
+    }
+  }
+}

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/VehiclePositionsForAgencyAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/VehiclePositionsForAgencyAction.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.actions.api.gtfs_realtime;
+
+import org.onebusaway.geospatial.model.CoordinatePoint;
+import org.onebusaway.transit_data.model.ListBean;
+import org.onebusaway.transit_data.model.RouteBean;
+import org.onebusaway.transit_data.model.VehicleStatusBean;
+import org.onebusaway.transit_data.model.trips.TripBean;
+import org.onebusaway.transit_data.model.trips.TripStatusBean;
+
+import com.google.transit.realtime.GtfsRealtime.FeedEntity;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtime.Position;
+import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
+import com.google.transit.realtime.GtfsRealtime.VehicleDescriptor;
+import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
+
+public class VehiclePositionsForAgencyAction extends GtfsRealtimeActionSupport {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  protected void fillFeedMessage(FeedMessage.Builder feed, String agencyId,
+      long timestamp) {
+
+    ListBean<VehicleStatusBean> vehicles = _service.getAllVehiclesForAgency(
+        agencyId, timestamp);
+
+    for (VehicleStatusBean vehicle : vehicles.getList()) {
+      FeedEntity.Builder entity = feed.addEntityBuilder();
+      entity.setId(Integer.toString(feed.getEntityCount()));
+      VehiclePosition.Builder vehiclePosition = entity.getVehicleBuilder();
+
+      TripStatusBean tripStatus = vehicle.getTripStatus();
+      if (tripStatus != null) {
+        TripBean activeTrip = tripStatus.getActiveTrip();
+        RouteBean route = activeTrip.getRoute();
+
+        TripDescriptor.Builder tripDesc = vehiclePosition.getTripBuilder();
+        tripDesc.setTripId(normalizeId(activeTrip.getId()));
+        tripDesc.setRouteId(normalizeId(route.getId()));
+      }
+
+      VehicleDescriptor.Builder vehicleDesc = vehiclePosition.getVehicleBuilder();
+      vehicleDesc.setId(normalizeId(vehicle.getVehicleId()));
+
+      CoordinatePoint location = vehicle.getLocation();
+      if (location != null) {
+        Position.Builder position = vehiclePosition.getPositionBuilder();
+        position.setLatitude((float) location.getLat());
+        position.setLongitude((float) location.getLon());
+      }
+
+      vehiclePosition.setTimestamp(vehicle.getLastUpdateTime() / 1000);
+    }
+  }
+}

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/impl/CustomProtocolBufferHandler.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/impl/CustomProtocolBufferHandler.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.impl;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.struts2.ServletActionContext;
+import org.apache.struts2.rest.handler.ContentTypeHandler;
+import org.onebusaway.api.model.ResponseBean;
+
+import com.google.protobuf.Message;
+
+public class CustomProtocolBufferHandler implements ContentTypeHandler {
+
+  @Override
+  public void toObject(Reader in, Object target) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String fromObject(Object obj, String resultCode, Writer stream)
+      throws IOException {
+    ResponseBean response = (ResponseBean) obj;
+    Message message = (Message) response.getData();
+    /**
+     * Instead of writing to the output Writer, we write directly to the
+     * HttpServletResponse output stream. That way, we can avoid any weirdness
+     * with encoding the serialized protobuf to a String.
+     */
+    HttpServletResponse res = ServletActionContext.getResponse();
+    message.writeTo(res.getOutputStream());
+    return null;
+  }
+
+  @Override
+  public String getContentType() {
+    return "application/x-google-protobuf";
+  }
+
+  @Override
+  public String getExtension() {
+    return "pb";
+  }
+}

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/impl/CustomProtocolBufferTextHandler.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/impl/CustomProtocolBufferTextHandler.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.impl;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+
+import org.apache.struts2.rest.handler.ContentTypeHandler;
+import org.onebusaway.api.model.ResponseBean;
+
+import com.google.protobuf.Message;
+
+public class CustomProtocolBufferTextHandler implements ContentTypeHandler {
+
+  @Override
+  public void toObject(Reader in, Object target) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String fromObject(Object obj, String resultCode, Writer stream)
+      throws IOException {
+    ResponseBean response = (ResponseBean) obj;
+    if (response.getData() != null) {
+      Message message = (Message) response.getData();
+      stream.write(message.toString());
+    }
+    return null;
+  }
+
+  @Override
+  public String getContentType() {
+    return "text/plain";
+  }
+
+  @Override
+  public String getExtension() {
+    return "pbtext";
+  }
+}

--- a/onebusaway-api-webapp/src/main/resources/struts-onebusaway-api-webapp.xml
+++ b/onebusaway-api-webapp/src/main/resources/struts-onebusaway-api-webapp.xml
@@ -26,10 +26,14 @@
     <bean name="myXml" type="org.apache.struts2.rest.handler.ContentTypeHandler" class="org.onebusaway.api.impl.CustomXStreamHandler" />
     <bean name="myJson" type="org.apache.struts2.rest.handler.ContentTypeHandler" class="org.onebusaway.api.impl.CustomJsonLibHandler" />
     <bean name="myCsv" type="org.apache.struts2.rest.handler.ContentTypeHandler" class="org.onebusaway.api.impl.CustomCsvHandler" />
+    <bean name="myProtocolBuffer" type="org.apache.struts2.rest.handler.ContentTypeHandler" class="org.onebusaway.api.impl.CustomProtocolBufferHandler" />
+    <bean name="myProtocolBufferText" type="org.apache.struts2.rest.handler.ContentTypeHandler" class="org.onebusaway.api.impl.CustomProtocolBufferTextHandler" />
     
     <constant name="struts.rest.handlerOverride.xml" value="myXml" />
     <constant name="struts.rest.handlerOverride.json" value="myJson" />
     <constant name="struts.rest.handlerOverride.csv" value="myCsv" />
+    <constant name="struts.rest.handlerOverride.pb" value="myProtocolBuffer" />
+    <constant name="struts.rest.handlerOverride.pbtext" value="myProtocolBufferText" />
     
     <package name="rest-custom" extends="rest-default">
 

--- a/onebusaway-api-webapp/src/main/resources/struts.xml
+++ b/onebusaway-api-webapp/src/main/resources/struts.xml
@@ -25,7 +25,7 @@
   <constant name="struts.convention.default.parent.package" value="rest-custom" />
   <constant name="struts.convention.package.locators.basePackage" value="org.onebusaway.api.actions" />
   <constant name="struts.convention.action.checkImplementsAction" value="false" />
-  <constant name="struts.action.extension" value="xhtml,,xml,json,csv" />
+  <constant name="struts.action.extension" value="xhtml,,xml,json,csv,pb,pbtext" />
   <!--
     This exclusion pattern is here because of the difference in how Tomcat and Jetty handle matching requests for the
     url "/".  Tomcat doesn't match it (even though the Struts prepare-and-execute filter is setup to match "/*"), so

--- a/onebusaway-api-webapp/src/test/java/org/onebusaway/api/actions/api/gtfs_realtime/AlertsForAgencyActionTest.java
+++ b/onebusaway-api-webapp/src/test/java/org/onebusaway/api/actions/api/gtfs_realtime/AlertsForAgencyActionTest.java
@@ -1,0 +1,176 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.actions.api.gtfs_realtime;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.onebusaway.api.model.ResponseBean;
+import org.onebusaway.transit_data.model.ListBean;
+import org.onebusaway.transit_data.model.service_alerts.NaturalLanguageStringBean;
+import org.onebusaway.transit_data.model.service_alerts.ServiceAlertBean;
+import org.onebusaway.transit_data.model.service_alerts.SituationAffectsBean;
+import org.onebusaway.transit_data.model.service_alerts.TimeRangeBean;
+import org.onebusaway.transit_data.services.TransitDataService;
+
+import com.google.transit.realtime.GtfsRealtime.Alert;
+import com.google.transit.realtime.GtfsRealtime.EntitySelector;
+import com.google.transit.realtime.GtfsRealtime.FeedEntity;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtime.TimeRange;
+import com.google.transit.realtime.GtfsRealtime.TranslatedString;
+import com.google.transit.realtime.GtfsRealtime.TranslatedString.Translation;
+
+public class AlertsForAgencyActionTest {
+
+  private AlertsForAgencyAction _action;
+
+  private TransitDataService _service;
+
+  @Before
+  public void before() {
+    _action = new AlertsForAgencyAction();
+
+    _service = Mockito.mock(TransitDataService.class);
+    _action.setTransitDataService(_service);
+  }
+
+  @Test
+  public void test() {
+    long now = System.currentTimeMillis();
+
+    List<ServiceAlertBean> alerts = new ArrayList<ServiceAlertBean>();
+
+    {
+      ServiceAlertBean alert = new ServiceAlertBean();
+      alerts.add(alert);
+      TimeRangeBean range = new TimeRangeBean(1234 * 1000, 5678 * 1000);
+      alert.setActiveWindows(Arrays.asList(range));
+      SituationAffectsBean affects = new SituationAffectsBean();
+      affects.setAgencyId("1");
+      affects.setRouteId("1_r0");
+      affects.setStopId("1_s0");
+      affects.setTripId("1_t0");
+      SituationAffectsBean alsoAffects = new SituationAffectsBean();
+      alsoAffects.setAgencyId("2");
+      alert.setAllAffects(Arrays.asList(affects, alsoAffects));
+      alert.setSummaries(Arrays.asList(new NaturalLanguageStringBean("Name",
+          "en"), new NaturalLanguageStringBean("Nombre", "es")));
+      alert.setDescriptions(Arrays.asList(new NaturalLanguageStringBean(
+          "Description", "en"), new NaturalLanguageStringBean("Descripción",
+          "es")));
+    }
+    {
+      ServiceAlertBean alert = new ServiceAlertBean();
+      alerts.add(alert);
+      TimeRangeBean range = new TimeRangeBean(5678 * 1000, 1234 * 1000);
+      alert.setActiveWindows(Arrays.asList(range));
+      SituationAffectsBean affects = new SituationAffectsBean();
+      affects.setAgencyId("2");
+      affects.setRouteId("1_r1");
+      affects.setStopId("1_s1");
+      affects.setTripId("1_t1");
+      alert.setAllAffects(Arrays.asList(affects));
+      alert.setSummaries(Arrays.asList(new NaturalLanguageStringBean("Name",
+          "en")));
+      alert.setDescriptions(Arrays.asList(new NaturalLanguageStringBean(
+          "Description", "en")));
+    }
+    ListBean<ServiceAlertBean> bean = new ListBean<ServiceAlertBean>();
+    bean.setList(alerts);
+    Mockito.when(_service.getAllServiceAlertsForAgencyId("1")).thenReturn(bean);
+
+    _action.setId("1");
+    _action.setTime(new Date(now));
+
+    _action.show();
+
+    ResponseBean model = _action.getModel();
+    FeedMessage feed = (FeedMessage) model.getData();
+    assertEquals(now / 1000, feed.getHeader().getTimestamp());
+    assertEquals(2, feed.getEntityCount());
+
+    {
+      FeedEntity entity = feed.getEntity(0);
+      assertEquals("1", entity.getId());
+      Alert alert = entity.getAlert();
+      assertEquals(1, alert.getActivePeriodCount());
+      TimeRange range = alert.getActivePeriod(0);
+      assertEquals(1234, range.getStart());
+      assertEquals(5678, range.getEnd());
+      assertEquals(2, alert.getInformedEntityCount());
+      {
+        EntitySelector affects = alert.getInformedEntity(0);
+        assertEquals("1", affects.getAgencyId());
+        assertEquals("r0", affects.getRouteId());
+        assertEquals("t0", affects.getTrip().getTripId());
+        assertEquals("s0", affects.getStopId());
+      }
+      {
+        EntitySelector affects = alert.getInformedEntity(1);
+        assertEquals("2", affects.getAgencyId());
+      }
+      TranslatedString header = alert.getHeaderText();
+      assertEquals(2, header.getTranslationCount());
+      {
+        Translation translation = header.getTranslation(0);
+        assertEquals("Name", translation.getText());
+        assertEquals("en", translation.getLanguage());
+      }
+      {
+        Translation translation = header.getTranslation(1);
+        assertEquals("Nombre", translation.getText());
+        assertEquals("es", translation.getLanguage());
+      }
+      TranslatedString description = alert.getDescriptionText();
+      assertEquals(2, description.getTranslationCount());
+      {
+        Translation translation = description.getTranslation(0);
+        assertEquals("Description", translation.getText());
+        assertEquals("en", translation.getLanguage());
+      }
+      {
+        Translation translation = description.getTranslation(1);
+        assertEquals("Descripción", translation.getText());
+        assertEquals("es", translation.getLanguage());
+      }
+    }
+    {
+      FeedEntity entity = feed.getEntity(1);
+      assertEquals("2", entity.getId());
+      Alert alert = entity.getAlert();
+      assertEquals(1, alert.getActivePeriodCount());
+      TimeRange range = alert.getActivePeriod(0);
+      assertEquals(5678, range.getStart());
+      assertEquals(1234, range.getEnd());
+      assertEquals(1, alert.getInformedEntityCount());
+      {
+        EntitySelector affects = alert.getInformedEntity(0);
+        assertEquals("2", affects.getAgencyId());
+        assertEquals("r1", affects.getRouteId());
+        assertEquals("t1", affects.getTrip().getTripId());
+        assertEquals("s1", affects.getStopId());
+      }
+    }
+  }
+}

--- a/onebusaway-api-webapp/src/test/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyActionTest.java
+++ b/onebusaway-api-webapp/src/test/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyActionTest.java
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.actions.api.gtfs_realtime;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.onebusaway.api.model.ResponseBean;
+import org.onebusaway.transit_data.model.ListBean;
+import org.onebusaway.transit_data.model.RouteBean;
+import org.onebusaway.transit_data.model.StopBean;
+import org.onebusaway.transit_data.model.VehicleStatusBean;
+import org.onebusaway.transit_data.model.trips.TripBean;
+import org.onebusaway.transit_data.model.trips.TripStatusBean;
+import org.onebusaway.transit_data.services.TransitDataService;
+
+import com.google.transit.realtime.GtfsRealtime.FeedEntity;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtime.TripUpdate;
+import com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate;
+
+public class TripUpdatesForAgencyActionTest {
+
+  private TripUpdatesForAgencyAction _action;
+
+  private TransitDataService _service;
+
+  @Before
+  public void before() {
+    _action = new TripUpdatesForAgencyAction();
+
+    _service = Mockito.mock(TransitDataService.class);
+    _action.setTransitDataService(_service);
+  }
+
+  @Test
+  public void test() {
+    long now = System.currentTimeMillis();
+
+    List<VehicleStatusBean> vehicles = new ArrayList<VehicleStatusBean>();
+    RouteBean.Builder routeBuilder = RouteBean.builder();
+    routeBuilder.setId("1_r1");
+    RouteBean route = routeBuilder.create();
+
+    {
+      VehicleStatusBean vehicle = new VehicleStatusBean();
+      vehicles.add(vehicle);
+      vehicle.setLastUpdateTime(1234 * 1000);
+      vehicle.setVehicleId("1_v1");
+
+      TripStatusBean tripStatus = new TripStatusBean();
+      vehicle.setTripStatus(tripStatus);
+
+      TripBean trip = new TripBean();
+      trip.setId("1_t0");
+      trip.setRoute(route);
+      tripStatus.setActiveTrip(trip);
+
+      StopBean stop = new StopBean();
+      stop.setId("1_s2");
+      tripStatus.setNextStop(stop);
+      tripStatus.setNextStopTimeOffset(5 * 60);
+    }
+    {
+      VehicleStatusBean vehicle = new VehicleStatusBean();
+      vehicles.add(vehicle);
+      vehicle.setLastUpdateTime(5678 * 1000);
+      vehicle.setVehicleId("1_v2");
+
+      TripStatusBean tripStatus = new TripStatusBean();
+      vehicle.setTripStatus(tripStatus);
+
+      TripBean trip = new TripBean();
+      trip.setId("1_t1");
+      trip.setRoute(route);
+      tripStatus.setActiveTrip(trip);
+
+      StopBean stop = new StopBean();
+      stop.setId("1_s3");
+      tripStatus.setNextStop(stop);
+      tripStatus.setNextStopTimeOffset(10 * 60);
+    }
+
+    ListBean<VehicleStatusBean> bean = new ListBean<VehicleStatusBean>();
+    bean.setList(vehicles);
+    Mockito.when(_service.getAllVehiclesForAgency("1", now)).thenReturn(bean);
+
+    _action.setId("1");
+    _action.setTime(new Date(now));
+
+    _action.show();
+    
+    ResponseBean model = _action.getModel();
+    FeedMessage feed = (FeedMessage) model.getData();
+    assertEquals(now / 1000, feed.getHeader().getTimestamp());
+    assertEquals(2, feed.getEntityCount());
+
+    {
+      FeedEntity entity = feed.getEntity(0);
+      assertEquals("1", entity.getId());
+      TripUpdate tripUpdate = entity.getTripUpdate();
+      assertEquals("t0", tripUpdate.getTrip().getTripId());
+      assertEquals("r1", tripUpdate.getTrip().getRouteId());
+      assertEquals("v1", tripUpdate.getVehicle().getId());
+      assertEquals(1234, tripUpdate.getTimestamp());
+      assertEquals(1, tripUpdate.getStopTimeUpdateCount());
+      StopTimeUpdate stopTimeUpdate = tripUpdate.getStopTimeUpdate(0);
+      assertEquals("s2", stopTimeUpdate.getStopId());
+      assertEquals(now / 1000 + 5 * 60, stopTimeUpdate.getDeparture().getTime());
+    }
+    {
+      FeedEntity entity = feed.getEntity(1);
+      assertEquals("2", entity.getId());
+      TripUpdate tripUpdate = entity.getTripUpdate();
+      assertEquals("t1", tripUpdate.getTrip().getTripId());
+      assertEquals("r1", tripUpdate.getTrip().getRouteId());
+      assertEquals("v2", tripUpdate.getVehicle().getId());
+      assertEquals(5678, tripUpdate.getTimestamp());
+      assertEquals(1, tripUpdate.getStopTimeUpdateCount());
+      StopTimeUpdate stopTimeUpdate = tripUpdate.getStopTimeUpdate(0);
+      assertEquals("s3", stopTimeUpdate.getStopId());
+      assertEquals(now / 1000 + 10 * 60,
+          stopTimeUpdate.getDeparture().getTime());
+    }
+  }
+}

--- a/onebusaway-api-webapp/src/test/java/org/onebusaway/api/actions/api/gtfs_realtime/VehiclePositionsForAgencyActionTest.java
+++ b/onebusaway-api-webapp/src/test/java/org/onebusaway/api/actions/api/gtfs_realtime/VehiclePositionsForAgencyActionTest.java
@@ -1,0 +1,134 @@
+/**
+ * Copyright (C) 2013 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.actions.api.gtfs_realtime;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.onebusaway.api.model.ResponseBean;
+import org.onebusaway.geospatial.model.CoordinatePoint;
+import org.onebusaway.transit_data.model.ListBean;
+import org.onebusaway.transit_data.model.RouteBean;
+import org.onebusaway.transit_data.model.VehicleStatusBean;
+import org.onebusaway.transit_data.model.trips.TripBean;
+import org.onebusaway.transit_data.model.trips.TripStatusBean;
+import org.onebusaway.transit_data.services.TransitDataService;
+
+import com.google.transit.realtime.GtfsRealtime.FeedEntity;
+import com.google.transit.realtime.GtfsRealtime.FeedMessage;
+import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
+
+public class VehiclePositionsForAgencyActionTest {
+
+  private VehiclePositionsForAgencyAction _action;
+
+  private TransitDataService _service;
+
+  @Before
+  public void before() {
+    _action = new VehiclePositionsForAgencyAction();
+
+    _service = Mockito.mock(TransitDataService.class);
+    _action.setTransitDataService(_service);
+  }
+
+  @Test
+  public void test() {
+    long now = System.currentTimeMillis();
+
+    List<VehicleStatusBean> vehicles = new ArrayList<VehicleStatusBean>();
+    RouteBean.Builder routeBuilder = RouteBean.builder();
+    routeBuilder.setId("1_r1");
+    RouteBean route = routeBuilder.create();
+
+    {
+      VehicleStatusBean vehicle = new VehicleStatusBean();
+      vehicles.add(vehicle);
+      vehicle.setLastUpdateTime(1234 * 1000);
+      vehicle.setVehicleId("1_v1");
+
+      TripStatusBean tripStatus = new TripStatusBean();
+      vehicle.setTripStatus(tripStatus);
+
+      TripBean trip = new TripBean();
+      trip.setId("1_t0");
+      trip.setRoute(route);
+      tripStatus.setActiveTrip(trip);
+
+      vehicle.setLocation(new CoordinatePoint(47.0, -122.0));
+    }
+    {
+      VehicleStatusBean vehicle = new VehicleStatusBean();
+      vehicles.add(vehicle);
+      vehicle.setLastUpdateTime(5678 * 1000);
+      vehicle.setVehicleId("1_v2");
+
+      TripStatusBean tripStatus = new TripStatusBean();
+      vehicle.setTripStatus(tripStatus);
+
+      TripBean trip = new TripBean();
+      trip.setId("1_t1");
+      trip.setRoute(route);
+      tripStatus.setActiveTrip(trip);
+
+      vehicle.setLocation(new CoordinatePoint(47.1, -122.1));
+    }
+
+    ListBean<VehicleStatusBean> bean = new ListBean<VehicleStatusBean>();
+    bean.setList(vehicles);
+    Mockito.when(_service.getAllVehiclesForAgency("1", now)).thenReturn(bean);
+
+    _action.setId("1");
+    _action.setTime(new Date(now));
+
+    _action.show();
+    
+    ResponseBean model = _action.getModel();
+    FeedMessage feed = (FeedMessage) model.getData();
+    assertEquals(now / 1000, feed.getHeader().getTimestamp());
+    assertEquals(2, feed.getEntityCount());
+
+    {
+      FeedEntity entity = feed.getEntity(0);
+      assertEquals("1", entity.getId());
+      VehiclePosition vehiclePosition = entity.getVehicle();
+      assertEquals("t0", vehiclePosition.getTrip().getTripId());
+      assertEquals("r1", vehiclePosition.getTrip().getRouteId());
+      assertEquals("v1", vehiclePosition.getVehicle().getId());
+      assertEquals(1234, vehiclePosition.getTimestamp());
+      assertEquals(47.0, vehiclePosition.getPosition().getLatitude(), 0.01);
+      assertEquals(-122.0, vehiclePosition.getPosition().getLongitude(), 0.01);
+    }
+
+    {
+      FeedEntity entity = feed.getEntity(1);
+      assertEquals("2", entity.getId());
+      VehiclePosition vehiclePosition = entity.getVehicle();
+      assertEquals("t1", vehiclePosition.getTrip().getTripId());
+      assertEquals("r1", vehiclePosition.getTrip().getRouteId());
+      assertEquals("v2", vehiclePosition.getVehicle().getId());
+      assertEquals(5678, vehiclePosition.getTimestamp());
+      assertEquals(47.1, vehiclePosition.getPosition().getLatitude(), 0.01);
+      assertEquals(-122.1, vehiclePosition.getPosition().getLongitude(), 0.01);
+    }
+  }
+}


### PR DESCRIPTION
This will expose the following API endpoints:

  /api/gtfs_realtime/alerts-for-agency/1.pb
  /api/gtfs_realtime/trip-updates-for-agency/1.pb
  /api/gtfs_realtime/vehicle-positions-for-agency/1.pb

which will return binary Protocol Buffer data in the GTFS-realtime schema.  The caller can optionally change the extension to .pbtext to see a textual debug representation of the message.

These methods are implemented with existing TransitDataService methods and can be thought of as a GTFS-realtime version of existing API methods like vehicles-for-agency.
