### PR TITLE
Add debug page to TDS for displaying bundle bounding box and WKT

### DIFF
--- a/onebusaway-transit-data-federation-webapp/src/main/java/org/onebusaway/transit_data_federation_webapp/controllers/BoundingBoxController.java
+++ b/onebusaway-transit-data-federation-webapp/src/main/java/org/onebusaway/transit_data_federation_webapp/controllers/BoundingBoxController.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2013 Kurt Raschke <kurt@kurtraschke.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation_webapp.controllers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.MultiPolygon;
+import com.vividsolutions.jts.geom.Polygon;
+
+import org.onebusaway.geospatial.model.CoordinateBounds;
+import org.onebusaway.transit_data_federation.services.AgencyService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+@Controller
+@RequestMapping("/bounding-box.action")
+public class BoundingBoxController {
+
+  @Autowired
+  private AgencyService _agencyService;
+
+  @RequestMapping()
+  public ModelAndView index() {
+
+    GeometryFactory gf = new GeometryFactory();
+    List<Polygon> polygons = new ArrayList<Polygon>();
+      
+    Map<String, CoordinateBounds> agencies = _agencyService.getAgencyIdsAndCoverageAreas();
+
+    for (CoordinateBounds cb: agencies.values()) {
+        Envelope e = new Envelope(cb.getMinLon(), cb.getMaxLon(), cb.getMinLat(), cb.getMaxLat());
+        Polygon p = (Polygon) gf.toGeometry(e);
+        polygons.add(p);
+    }
+    
+    MultiPolygon mp = gf.createMultiPolygon(polygons.toArray(new Polygon[0]));
+    
+    Geometry hull = mp.convexHull();
+    Envelope env = hull.getEnvelopeInternal();
+
+    ModelAndView mv = new ModelAndView("bounding-box.jspx");
+    mv.addObject("minY", env.getMinY());
+    mv.addObject("minX", env.getMinX());
+    mv.addObject("maxY", env.getMaxY());
+    mv.addObject("maxX", env.getMaxX());
+    mv.addObject("hullWKT", hull.toText());
+    return mv;
+  }
+}

--- a/onebusaway-transit-data-federation-webapp/src/main/webapp/WEB-INF/jsp/bounding-box.jspx
+++ b/onebusaway-transit-data-federation-webapp/src/main/webapp/WEB-INF/jsp/bounding-box.jspx
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (C) 2013 Kurt Raschke <kurt@kurtraschke.com>
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<html xmlns:jsp="http://java.sun.com/JSP/Page"
+    xmlns:c="http://java.sun.com/jsp/jstl/core">
+    <jsp:directive.page contentType="text/html" />
+<head>
+<title>Bounding Box</title>
+</head>
+<body>
+    <h1>Bundle Bounding Box</h1>
+    <dl>
+        <dt>minLat</dt>
+        <dd><code><pre><c:out value="${minY}" /></pre></code></dd>
+        <dt>minLon</dt>
+        <dd><code><pre><c:out value="${minX}" /></pre></code></dd>
+        <dt>maxLat</dt>
+        <dd><code><pre><c:out value="${maxY}" /></pre></code></dd>
+        <dt>maxLon</dt>
+        <dd><code><pre><c:out value="${maxX}" /></pre></code></dd>
+        <dt>Filter WKT</dt>
+        <dd><code><pre><c:out value="${hullWKT}" /></pre></code></dd>
+    </dl>
+</body>
+</html>


### PR DESCRIPTION
When setting up the OBA webapps, it is necessary to have the current bundle's geographic coverage, and, for OBANYC, a WKT polygon for filtering geocoder results.

Service area can be computed automatically, [except](https://groups.google.com/d/msg/onebusaway-developers/1Ip_zu_atjg/WBRSXAGTTS0J) when the UI webapp is running in the same container as the TDS.  These values can also be found with [an external script](https://gist.github.com/kurtraschke/4323377), but that is a nuisance.

This pull request implements a debug page in the TDS which displays the bounding box values and filter WKT, easing deployments of the webapps.
