### PR TITLE
Fix spelling error in GtfsRealtimeActionSupport.

### DIFF
--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/GtfsRealtimeActionSupport.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/GtfsRealtimeActionSupport.java
@@ -66,7 +66,7 @@ public abstract class GtfsRealtimeActionSupport extends ApiActionSupport {
     _time = time.getTime();
   }
 
-  public void setRemoveAgencyIsd(boolean removeAgencyIds) {
+  public void setRemoveAgencyIds(boolean removeAgencyIds) {
     _removeAgencyIds = removeAgencyIds;
   }
 


### PR DESCRIPTION
This is a follow-on to #52 and fixes a minor spelling error in `GtfsRealtimeActionSupport`.
