### PR TITLE
Bump ApspectJ version to 1.7.3 so it doesn't crash OBA when run with with a Java 1.7 VM

### DIFF
--- a/onebusaway-container/pom.xml
+++ b/onebusaway-container/pom.xml
@@ -11,7 +11,7 @@
     <name>onebusaway-container</name>
 
     <properties>
-        <aspectj-version>1.5.4</aspectj-version>
+        <aspectj-version>1.7.3</aspectj-version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Currently, if you attempt to run the OBA application suite with a Java 1.7 VM, it crashes with the following error:

java.lang.IllegalArgumentException: error the @annotation pointcut expression is only supported at Java 5 compliance level or above

This is apparently an issue with the AspectJ 1.5.x series and Java 1.7, according to:

http://stackoverflow.com/questions/15678417/error-when-using-aspectj-aop-with-java-7

I've tested this by running the onebusaway quickstart against both a Java 1.6 and 1.7 runtime to verify that it works with both.
