### PR TITLE
Fix #64 - Change `api.onebusaway.org` to `api.pugetsound.onebusaway.org` in REST API documentation

### DIFF
--- a/src/site/markdown/api/where/methods/agencies-with-coverage.md
+++ b/src/site/markdown/api/where/methods/agencies-with-coverage.md
@@ -6,7 +6,7 @@ Returns a list of all transit agencies currently supported by OneBusAway along w
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/agencies-with-coverage.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/agencies-with-coverage.xml?key=TEST
 
 ## Sample Response
 

--- a/src/site/markdown/api/where/methods/agency.md
+++ b/src/site/markdown/api/where/methods/agency.md
@@ -6,7 +6,7 @@ Retrieve info for a specific transit agency identified by id
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/agency/1.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/agency/1.xml?key=TEST
 
 ## Sample Response
 
@@ -32,7 +32,7 @@ http://api.onebusaway.org/api/where/agency/1.xml?key=TEST
 ## Request Parameters
 
 * id - the id of the agency, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/agency/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/agency/[ID GOES HERE].xml`
 
 ### Response
 

--- a/src/site/markdown/api/where/methods/arrival-and-departure-for-stop.md
+++ b/src/site/markdown/api/where/methods/arrival-and-departure-for-stop.md
@@ -6,7 +6,7 @@ Get info about a single arrival and departure for a stop
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/arrival-and-departure-for-stop/1_75403.xml?key=TEST&tripId=1_15551341&serviceDate=1291536000000&vehicleId=1_3521&stopSequence=42
+http://api.pugetsound.onebusaway.org/api/where/arrival-and-departure-for-stop/1_75403.xml?key=TEST&tripId=1_15551341&serviceDate=1291536000000&vehicleId=1_3521&stopSequence=42
 
 ## Sample Response
 
@@ -26,7 +26,7 @@ http://api.onebusaway.org/api/where/arrival-and-departure-for-stop/1_75403.xml?k
 ## Request Parameters
 
 * id - the stop id, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/arrival-and-departure-for-stop/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/arrival-and-departure-for-stop/[ID GOES HERE].xml`
 * tripId - the trip id of the arriving transit vehicle
 * serviceDate - the service date of the arriving transit vehicle
 * vehicleId - the vehicle id of the arriving transit vehicle (optional)

--- a/src/site/markdown/api/where/methods/arrivals-and-departures-for-stop.md
+++ b/src/site/markdown/api/where/methods/arrivals-and-departures-for-stop.md
@@ -6,7 +6,7 @@ Get current arrivals and departures for a stop identified by id
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_75403.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_75403.xml?key=TEST
 
 ## Sample Response
 
@@ -35,7 +35,7 @@ http://api.onebusaway.org/api/where/arrivals-and-departures-for-stop/1_75403.xml
 ## Request Parameters
 
 * id - the stop id, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/arrivals-and-departures-for-stop/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/[ID GOES HERE].xml`
 * minutesBefore=n - include vehicles having arrived or departed in the previous n minutes (default=5)
 * minutesAfter=n - include vehicles arriving or departing in the next n minutes (default=35)
 * time=n - the time for which the schedule will be generated, as either ms since the unix epoch or of the form YYYY-MM-DD_HH-MM-SS (note this doesn't currently deal well with timezones).  The default query time is NOW.

--- a/src/site/markdown/api/where/methods/cancel-alarm.md
+++ b/src/site/markdown/api/where/methods/cancel-alarm.md
@@ -6,7 +6,7 @@ Cancel a registered alarm.
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/cancel_alarm/1_00859082-9b9d-4f72-a89f-c4be0e2cf01a.xml
+http://api.pugetsound.onebusaway.org/api/where/cancel_alarm/1_00859082-9b9d-4f72-a89f-c4be0e2cf01a.xml
 
 ## Sample Response
 
@@ -23,6 +23,6 @@ http://api.onebusaway.org/api/where/cancel_alarm/1_00859082-9b9d-4f72-a89f-c4be0
 ## Request Parameters
 
 * id - the alarm id is encoded directly in the URL
-    * `http://api.onebusaway.org/api/where/cancel_alarm/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/cancel_alarm/[ID GOES HERE].xml`
 
 The alarm id is returned in the call to [register-alarm-for-arrival-and-departure-at-stop](register-alarm-for-arrival-and-departure-at-stop.html) api method.

--- a/src/site/markdown/api/where/methods/current-time.md
+++ b/src/site/markdown/api/where/methods/current-time.md
@@ -6,7 +6,7 @@ Retrieve the current system time
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/current-time.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/current-time.xml?key=TEST
 
 ## Sample Response
 

--- a/src/site/markdown/api/where/methods/plan-trip.md
+++ b/src/site/markdown/api/where/methods/plan-trip.md
@@ -8,7 +8,7 @@ This method allows you to plan a trip using public transit between locations.  D
 
 ## Sample Request
 
-http://soak-api.onebusaway.org/api/where/plan-trip.xml?key=TEST&latFrom=47.669940&lonFrom=-122.387958&latTo=47.598941&lonTo=-122.331138&time=2011-01-31_12-48-00
+http://soak-api.pugetsound.onebusaway.org/api/where/plan-trip.xml?key=TEST&latFrom=47.669940&lonFrom=-122.387958&latTo=47.598941&lonTo=-122.331138&time=2011-01-31_12-48-00
 
 ## Sample Response
 

--- a/src/site/markdown/api/where/methods/register-alarm-for-arrival-and-departure-at-stop.md
+++ b/src/site/markdown/api/where/methods/register-alarm-for-arrival-and-departure-at-stop.md
@@ -6,7 +6,7 @@ Register an alarm for a single arrival and departure at a stop, with a callback 
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/register-alarm-for-arrival-and-departure-at-stop/1_75403.xml?key=TEST&tripId=1_15551341&serviceDate=1291536000000&vehicleId=1_3521&stopSequence=42&alarmTimeOffset=120&url=http://host/callback_url
+http://api.pugetsound.onebusaway.org/api/where/register-alarm-for-arrival-and-departure-at-stop/1_75403.xml?key=TEST&tripId=1_15551341&serviceDate=1291536000000&vehicleId=1_3521&stopSequence=42&alarmTimeOffset=120&url=http://host/callback_url
 
 ## Sample Response
 

--- a/src/site/markdown/api/where/methods/report-problem-with-stop.md
+++ b/src/site/markdown/api/where/methods/report-problem-with-stop.md
@@ -9,7 +9,7 @@ problem reporting admin interface.
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/report-problem-with-stop/1_75403.xml?key=TEST&code=stop_name_wrong
+http://api.pugetsound.onebusaway.org/api/where/report-problem-with-stop/1_75403.xml?key=TEST&code=stop_name_wrong
 
 ## Sample Response
 
@@ -26,7 +26,7 @@ http://api.onebusaway.org/api/where/report-problem-with-stop/1_75403.xml?key=TES
 ## Request Parameters
 
 * stopId - the trip id, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/report-problem-with-stop/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/report-problem-with-stop/[ID GOES HERE].xml`
 * code - a string code identifying the nature of the problem
     * `stop_name_wrong` - the stop name in OneBusAway differs from the actual stop's name
     * `stop_number_wrong` - the stop number in OneBusAway differs from the actual stop's number

--- a/src/site/markdown/api/where/methods/report-problem-with-trip.md
+++ b/src/site/markdown/api/where/methods/report-problem-with-trip.md
@@ -9,7 +9,7 @@ problem reporting admin interface.
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/report-problem-with-trip/1_79430293.xml?key=TEST&serviceDate=1291536000000&vehicleId=1_3521&stopId=1_75403&code=vehicle_never_came
+http://api.pugetsound.onebusaway.org/api/where/report-problem-with-trip/1_79430293.xml?key=TEST&serviceDate=1291536000000&vehicleId=1_3521&stopId=1_75403&code=vehicle_never_came
 
 ## Sample Response
 
@@ -26,7 +26,7 @@ http://api.onebusaway.org/api/where/report-problem-with-trip/1_79430293.xml?key=
 ## Request Parameters
 
 * tripId - the trip id, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/report-problem-with-trip/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/report-problem-with-trip/[ID GOES HERE].xml`
 * serviceDate - the service date of the trip
 * vehicleId - the vehicle actively serving the trip
 * stopId - a stop id indicating the stop where the user is experiencing the problem 

--- a/src/site/markdown/api/where/methods/route-ids-for-agency.md
+++ b/src/site/markdown/api/where/methods/route-ids-for-agency.md
@@ -6,7 +6,7 @@ Retrieve the list of all route ids for a particular agency.
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/route-ids-for-agency/40.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/route-ids-for-agency/40.xml?key=TEST
 
 ## Sample Response
 
@@ -30,7 +30,7 @@ http://api.onebusaway.org/api/where/route-ids-for-agency/40.xml?key=TEST
 ## Request Parameters
 
 * id - the id of the agency, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/route-ids-for-agency/[ID GOES HERE].xml?key=TEST`
+    * `http://api.pugetsound.onebusaway.org/api/where/route-ids-for-agency/[ID GOES HERE].xml?key=TEST`
 
 ## Response
 

--- a/src/site/markdown/api/where/methods/route.md
+++ b/src/site/markdown/api/where/methods/route.md
@@ -6,7 +6,7 @@ Retrieve info for a specific route by id.
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/route/1_44.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/route/1_44.xml?key=TEST
 
 ## Sample Response
 
@@ -32,7 +32,7 @@ http://api.onebusaway.org/api/where/route/1_44.xml?key=TEST
 ## Request Parameters
 
 * `id` - the id of the route, encoded directly in the url
-    * `http://api.onebusaway.org/api/where/route/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/route/[ID GOES HERE].xml`
 
 ## Response
 

--- a/src/site/markdown/api/where/methods/routes-for-agency.md
+++ b/src/site/markdown/api/where/methods/routes-for-agency.md
@@ -6,7 +6,7 @@ Retrieve the list of all routes for a particular agency by id
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/routes-for-agency/1.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/routes-for-agency/1.xml?key=TEST
 
 ## Sample Response
 
@@ -35,7 +35,7 @@ http://api.onebusaway.org/api/where/routes-for-agency/1.xml?key=TEST
 ## Request Parameters
 
 * id - the id of the agency, encoded in the url directly
-    * `http://api.onebusaway.org/api/where/routes-for-agency/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/routes-for-agency/[ID GOES HERE].xml`
 
 ## Response
 

--- a/src/site/markdown/api/where/methods/routes-for-location.md
+++ b/src/site/markdown/api/where/methods/routes-for-location.md
@@ -6,7 +6,7 @@ Search for routes near a specific location, optionally by name
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/routes-for-location.xml?key=TEST&lat=47.653435&lon=-122.305641
+http://api.pugetsound.onebusaway.org/api/where/routes-for-location.xml?key=TEST&lat=47.653435&lon=-122.305641
 
 ## Sample Response
 

--- a/src/site/markdown/api/where/methods/schedule-for-stop.md
+++ b/src/site/markdown/api/where/methods/schedule-for-stop.md
@@ -6,7 +6,7 @@ Retrieve the full schedule for a stop on a particular day
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/schedule-for-stop/1_75403.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/schedule-for-stop/1_75403.xml?key=TEST
 
 ## Sample Response
 
@@ -56,7 +56,7 @@ http://api.onebusaway.org/api/where/schedule-for-stop/1_75403.xml?key=TEST
 ## Request Parameters
 
 * id - encoded in the url directly, this specifies the stop id to request the schedule for
-	* `http://api.onebusaway.org/api/where/schedule-for-stop/[ID GOES HERE].xml`
+	* `http://api.pugetsound.onebusaway.org/api/where/schedule-for-stop/[ID GOES HERE].xml`
 * date - The date for which you want to request a schedule of the format YYYY-MM-DD (optional, defaults to current date)
 
 ## Response

--- a/src/site/markdown/api/where/methods/shape.md
+++ b/src/site/markdown/api/where/methods/shape.md
@@ -6,7 +6,7 @@ Retrieve a shape (the path traveled by a transit vehicle) by id
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/shape/1_40046045.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/shape/1_40046045.xml?key=TEST
 
 ## Sample Response
 
@@ -37,7 +37,7 @@ http://api.onebusaway.org/api/where/shape/1_40046045.xml?key=TEST
 ## Request Parameters
 
 * `id` - the shape id is included directly in the url path
-    * `http://api.onebusaway.org/api/where/shape/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/shape/[ID GOES HERE].xml`
 
 ## Response
 

--- a/src/site/markdown/api/where/methods/stop-ids-for-agency.md
+++ b/src/site/markdown/api/where/methods/stop-ids-for-agency.md
@@ -6,7 +6,7 @@ Retrieve the list of all stops for a particular agency by id
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/stop-ids-for-agency/40.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/stop-ids-for-agency/40.xml?key=TEST
 
 ## Sample Response
 
@@ -30,7 +30,7 @@ http://api.onebusaway.org/api/where/stop-ids-for-agency/40.xml?key=TEST
 ## Request Parameters
 
 * id - the id of the agency, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/stop-ids-for-agency/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/stop-ids-for-agency/[ID GOES HERE].xml`
 
 ## Response
 

--- a/src/site/markdown/api/where/methods/stop.md
+++ b/src/site/markdown/api/where/methods/stop.md
@@ -6,7 +6,7 @@ Retrieve info for a specific stop by id
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/stop/1_75403.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/stop/1_75403.xml?key=TEST
 
 ## Sample Response
 
@@ -36,7 +36,7 @@ http://api.onebusaway.org/api/where/stop/1_75403.xml?key=TEST
 ## Request Parameters
 
 * `id` - the id of the requested stop, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/stop/[ID GOES HERE].xml` 
+    * `http://api.pugetsound.onebusaway.org/api/where/stop/[ID GOES HERE].xml` 
 
 ## Response
 

--- a/src/site/markdown/api/where/methods/stops-for-location.md
+++ b/src/site/markdown/api/where/methods/stops-for-location.md
@@ -6,7 +6,7 @@ Search for stops near a specific location, optionally by stop code
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/stops-for-location.xml?key=TEST&lat=47.653435&lon=-122.305641
+http://api.pugetsound.onebusaway.org/api/where/stops-for-location.xml?key=TEST&lat=47.653435&lon=-122.305641
 
 ## Sample Response
 

--- a/src/site/markdown/api/where/methods/stops-for-route.md
+++ b/src/site/markdown/api/where/methods/stops-for-route.md
@@ -6,7 +6,7 @@ Retrieve the set of stops serving a particular route, including groups by direct
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/stops-for-route/1_44.xml?key=TEST&version=2
+http://api.pugetsound.onebusaway.org/api/where/stops-for-route/1_44.xml?key=TEST&version=2
 
 ## Sample Response
 
@@ -58,7 +58,7 @@ http://api.onebusaway.org/api/where/stops-for-route/1_44.xml?key=TEST&version=2
 ## Request Parameters
 
 * `id` - The route id, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/stops-for-route/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/stops-for-route/[ID GOES HERE].xml`
 * includePolylines=true|false = Optional parameter that controls whether polyline elements are included in the response.  Defaults to true.
 
 ## Response

--- a/src/site/markdown/api/where/methods/trip-details.md
+++ b/src/site/markdown/api/where/methods/trip-details.md
@@ -6,7 +6,7 @@ Get extended details for a specific trip
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/trip-details/1_12540399.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/trip-details/1_12540399.xml?key=TEST
 
 ## Sample Response
 
@@ -32,7 +32,7 @@ http://api.onebusaway.org/api/where/trip-details/1_12540399.xml?key=TEST
 ## Request Parameters
 
 * id - the id of the trip, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/trip-details/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/trip-details/[ID GOES HERE].xml`
 * serviceDate - the service date for the trip as unix-time in ms (optional).  Used to disambiguate different versions of the same trip.  See [Glossary#ServiceDate the glossary entry for service date].
 * includeTrip - Can be true/false to determine whether full [`<trip/>`](../elements/trip.html) element is included in the `<references/>` section.  Defaults to true.
 * includeSchedule - Can be true/false to determine whether full `<schedule/>` element is included in the `<tripDetails/>` section.  Defaults to true.

--- a/src/site/markdown/api/where/methods/trip-for-vehicle.md
+++ b/src/site/markdown/api/where/methods/trip-for-vehicle.md
@@ -6,7 +6,7 @@ Get extended trip details for a specific transit vehicle.  That is, given a vehi
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/trip-for-vehicle/1_4210.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/trip-for-vehicle/1_4210.xml?key=TEST
 
 ## Sample Response
 
@@ -33,7 +33,7 @@ http://api.onebusaway.org/api/where/trip-for-vehicle/1_4210.xml?key=TEST
 ## Request Parameters
 
 * id - the id of the vehicle, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/trip-for-vehicle/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/trip-for-vehicle/[ID GOES HERE].xml`
 * includeTrip - Can be true/false to determine whether full [`<trip/>` element](../elements/trip.html) is included in the `<references/>` section.  Defaults to false.
 * includeSchedule - Can be true/false to determine whether full `<schedule/>` element is included in the `<tripDetails/>` section.  Defaults to fale.
 * includeStatus - Can be true/false to determine whether the full `<status/>` element is include in the `<tripDetails/>` section.  Defaults to true.

--- a/src/site/markdown/api/where/methods/trip.md
+++ b/src/site/markdown/api/where/methods/trip.md
@@ -6,7 +6,7 @@ Get details of a specific trip by id
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/trip/1_12540399.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/trip/1_12540399.xml?key=TEST
 
 ## Sample Response
 
@@ -32,7 +32,7 @@ http://api.onebusaway.org/api/where/trip/1_12540399.xml?key=TEST
 ## Request Parameters
 
 * id - the id of the trip, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/trip/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/trip/[ID GOES HERE].xml`
 
 ## Response
 

--- a/src/site/markdown/api/where/methods/trips-for-location.md
+++ b/src/site/markdown/api/where/methods/trips-for-location.md
@@ -6,7 +6,7 @@ Search for active trips near a specific location.
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/trips-for-location.xml?key=TEST&lat=47.653&lon=-122.307&latSpan=0.008&lonSpan=0.008
+http://api.pugetsound.onebusaway.org/api/where/trips-for-location.xml?key=TEST&lat=47.653&lon=-122.307&latSpan=0.008&lonSpan=0.008
 
 ## Sample Response
 

--- a/src/site/markdown/api/where/methods/trips-for-route.md
+++ b/src/site/markdown/api/where/methods/trips-for-route.md
@@ -6,7 +6,7 @@ Search for active trips for a specific route.
 
 ## Sample Request
 
-http://api.onebusaway.org/api/where/trips-for-route/1_44.xml?key=TEST
+http://api.pugetsound.onebusaway.org/api/where/trips-for-route/1_44.xml?key=TEST
 
 ## Sample Response
 
@@ -31,7 +31,7 @@ http://api.onebusaway.org/api/where/trips-for-route/1_44.xml?key=TEST
 ## Request Parameters
 
 * id - the id of the route, encoded directly in the url:
-    * `http://api.onebusaway.org/api/where/trips-for-route/[ID GOES HERE].xml`
+    * `http://api.pugetsound.onebusaway.org/api/where/trips-for-route/[ID GOES HERE].xml`
 * includeStatus - Can be true/false to determine whether full
 [`<tripStatus/>` elements](../elements/trip-status.html) with full real-time
 information are included in the `<status/>` section for each `<tripDetails/>`


### PR DESCRIPTION
Fix https://github.com/OneBusAway/onebusaway-application-modules/issues/64 -
Change `api.onebusaway.org` to `api.pugetsound.onebusaway.org` in REST
API documentation.
