### PR TITLE
Fix #41 - Stop element API docs ambiguous

### DIFF
--- a/src/site/markdown/api/where/elements/stop.md
+++ b/src/site/markdown/api/where/elements/stop.md
@@ -31,6 +31,7 @@ The following fields are optional:
 
 * direction
 * code
+* wheelchairBoarding
 
 The following values are supported for the `<wheelchairBoarding/>` element:
 


### PR DESCRIPTION
Fix #41 - Stop element API docs ambiguous.  Added explicit listing of `wheelchairBoarding` as an optional field.
