### PR TITLE
Fix underlying cause of breakage of trips-for-location API call

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockGeospatialServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/BlockGeospatialServiceImpl.java
@@ -146,19 +146,29 @@ class BlockGeospatialServiceImpl implements BlockGeospatialService {
 
     List<StopEntry> stops = _transitGraphDao.getStopsByLocation(bounds);
 
-    Set<BlockTripIndex> blockIndices = new HashSet<BlockTripIndex>();
+    Set<AgencyAndId> blockIds = new HashSet<AgencyAndId>();
 
     for (StopEntry stop : stops) {
-
-        List<BlockStopTimeIndex> stopTimeIndices = _blockIndexService.getStopTimeIndicesForStop(stop);
-        for (BlockStopTimeIndex stopTimeIndex : stopTimeIndices) {
-          for (BlockConfigurationEntry blockConfigurationEntry: stopTimeIndex.getBlockConfigs()) {
-            blockIndices.addAll(_blockIndexService.getBlockTripIndicesForBlock(blockConfigurationEntry.getBlock().getId()));
-          }
-        }
-       
+      List<BlockStopTimeIndex> stopTimeIndices = _blockIndexService.getStopTimeIndicesForStop(stop);
+      
+      Set<BlockConfigurationEntry> blockConfigs = new HashSet<BlockConfigurationEntry>();
+      
+      List<List<BlockConfigurationEntry>> blockConfigsList = MappingLibrary.map(stopTimeIndices, "blockConfigs");
+      
+      for (List<BlockConfigurationEntry> l: blockConfigsList) {
+        blockConfigs.addAll(l);
+      }
+     
+      List<AgencyAndId> stopBlockIds = MappingLibrary.map(blockConfigs, "block.id");
+      blockIds.addAll(stopBlockIds);      
     }
 
+    Set<BlockTripIndex> blockIndices = new HashSet<BlockTripIndex>();
+
+    for (AgencyAndId blockId: blockIds) {
+      blockIndices.addAll(_blockIndexService.getBlockTripIndicesForBlock(blockId));
+    }
+    
     List<BlockLayoverIndex> layoverIndices = Collections.emptyList();
     List<FrequencyBlockTripIndex> frequencyIndices = Collections.emptyList();
 


### PR DESCRIPTION
This PR fixes breakage of the trips-for-location API call, which was due to underlying changes in BlockGeospatialServiceImpl in d7cbb75f.

The first reports of this issue were on the Puget Sound instance (issue #46 and [the API mailing list](https://groups.google.com/d/topic/onebusaway-api/ygj7_s3LkLw/discussion)), and I verified that the issue existed locally as well (that is, it wasn't just a Puget Sound data or configuration problem).

With this patch applied the trips-for-location API call returns the expected results.
