### PR TITLE
Fix off-by-one error in assignment of distance-along-shape values when no shapes are available.

### DIFF
--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopTimeEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopTimeEntriesFactory.java
@@ -200,12 +200,12 @@ public class StopTimeEntriesFactory {
       double d = 0;
       StopTimeEntryImpl prev = null;
       for (StopTimeEntryImpl stopTime : stopTimes) {
-        stopTime.setShapeDistTraveled(d);
         if (prev != null) {
           CoordinatePoint from = prev.getStop().getStopLocation();
           CoordinatePoint to = stopTime.getStop().getStopLocation();
           d += SphericalGeometryLibrary.distance(from, to);
         }
+        stopTime.setShapeDistTraveled(d);
         prev = stopTime;
       }
     }


### PR DESCRIPTION
This bug in turn broke stoptime interpolation, because the first two stoptimes of a trip would both have distance-along-shape 0.

Here is one of the feeds that necessitated this patch: http://www.gtfs-data-exchange.com/agency/transit-services-of-frederick-county/latest.zip
