### PR TITLE
Preserve per-stoptime predictions from GTFS-realtime updates.

### DIFF
--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyAction.java
@@ -27,6 +27,7 @@ import com.google.transit.realtime.GtfsRealtime.FeedMessage;
 import com.google.transit.realtime.GtfsRealtime.TripDescriptor;
 import com.google.transit.realtime.GtfsRealtime.TripUpdate;
 import com.google.transit.realtime.GtfsRealtime.VehicleDescriptor;
+import org.onebusaway.transit_data.model.trips.TimepointPredictionBean;
 
 public class TripUpdatesForAgencyAction extends GtfsRealtimeActionSupport {
 
@@ -58,15 +59,26 @@ public class TripUpdatesForAgencyAction extends GtfsRealtimeActionSupport {
       VehicleDescriptor.Builder vehicleDesc = tripUpdate.getVehicleBuilder();
       vehicleDesc.setId(normalizeId(vehicle.getVehicleId()));
 
-      StopBean nextStop = tripStatus.getNextStop();
-      if (nextStop != null) {
-        TripUpdate.StopTimeUpdate.Builder stopTimeUpdate = tripUpdate.addStopTimeUpdateBuilder();
-        stopTimeUpdate.setStopId(normalizeId(nextStop.getId()));
-        TripUpdate.StopTimeEvent.Builder departure = stopTimeUpdate.getDepartureBuilder();
-        departure.setTime(timestamp / 1000 + tripStatus.getNextStopTimeOffset());
+      if (tripStatus.getTimepointPredictions() != null && tripStatus.getTimepointPredictions().size() > 0) {
+        for (TimepointPredictionBean timepointPrediction: tripStatus.getTimepointPredictions()) {
+          TripUpdate.StopTimeUpdate.Builder stopTimeUpdate = tripUpdate.addStopTimeUpdateBuilder();
+          stopTimeUpdate.setStopId(normalizeId(timepointPrediction.getTimepointId()));
+          TripUpdate.StopTimeEvent.Builder arrival = stopTimeUpdate.getArrivalBuilder();
+          arrival.setTime(timepointPrediction.getTimepointPredictedTime());
+        }
+        
+        tripUpdate.setTimestamp(vehicle.getLastUpdateTime() / 1000);
+      } else {
+        StopBean nextStop = tripStatus.getNextStop();
+        if (nextStop != null) {
+          TripUpdate.StopTimeUpdate.Builder stopTimeUpdate = tripUpdate.addStopTimeUpdateBuilder();
+          stopTimeUpdate.setStopId(normalizeId(nextStop.getId()));
+          TripUpdate.StopTimeEvent.Builder departure = stopTimeUpdate.getDepartureBuilder();
+          departure.setTime(timestamp / 1000 + tripStatus.getNextStopTimeOffset());
+        }
+        
+        tripUpdate.setTimestamp(vehicle.getLastUpdateTime() / 1000);
       }
-
-      tripUpdate.setTimestamp(vehicle.getLastUpdateTime() / 1000);
     }
   }
 }

--- a/onebusaway-transit-data-federation-webapp/src/main/java/org/onebusaway/transit_data_federation_webapp/controllers/gtfs_realtime/GtfsRealtimeController.java
+++ b/onebusaway-transit-data-federation-webapp/src/main/java/org/onebusaway/transit_data_federation_webapp/controllers/gtfs_realtime/GtfsRealtimeController.java
@@ -1,4 +1,5 @@
 /**
+ * Copyright (C) 2013 Kurt Raschke
  * Copyright (C) 2011 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,8 @@
 package org.onebusaway.transit_data_federation_webapp.controllers.gtfs_realtime;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime.GtfsRealtimeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,20 +38,32 @@ public class GtfsRealtimeController {
   }
 
   @RequestMapping(value = "/gtfs-realtime/trip-updates.action")
-  public void tripUpdates(OutputStream out) throws IOException {
+  public void tripUpdates(ServletRequest request, HttpServletResponse response) throws IOException {
     FeedMessage tripUpdates = _gtfsRealtimeService.getTripUpdates();
-    tripUpdates.writeTo(out);
+    render(request, response, tripUpdates);
   }
 
   @RequestMapping(value = "/gtfs-realtime/vehicle-positions.action")
-  public void vehiclePositions(OutputStream out) throws IOException {
+  public void vehiclePositions(ServletRequest request, HttpServletResponse response) throws IOException {
     FeedMessage vehiclePositions = _gtfsRealtimeService.getVehiclePositions();
-    vehiclePositions.writeTo(out);
+    render(request, response, vehiclePositions);
   }
 
   @RequestMapping(value = "/gtfs-realtime/alerts.action")
-  public void alerts(OutputStream out) throws IOException {
+  public void alerts(ServletRequest request, HttpServletResponse response) throws IOException {
     FeedMessage alerts = _gtfsRealtimeService.getAlerts();
-    alerts.writeTo(out);
+    render(request, response, alerts);
   }
+
+  private void render(ServletRequest request, HttpServletResponse response,
+          FeedMessage message) throws IOException {
+    if (request.getParameter("debug") != null) {
+      response.setContentType("text/plain");
+      response.getWriter().write(message.toString());
+    } else {
+      response.setContentType("application/x-google-protobuf");
+      message.writeTo(response.getOutputStream());
+   }
+  }
+
 }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/TripStatusBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/TripStatusBeanServiceImpl.java
@@ -22,11 +22,13 @@ import java.util.Map;
 
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.realtime.api.EVehiclePhase;
+import org.onebusaway.realtime.api.TimepointPredictionRecord;
 import org.onebusaway.transit_data.model.ListBean;
 import org.onebusaway.transit_data.model.StopBean;
 import org.onebusaway.transit_data.model.TripStopTimesBean;
 import org.onebusaway.transit_data.model.schedule.FrequencyBean;
 import org.onebusaway.transit_data.model.service_alerts.ServiceAlertBean;
+import org.onebusaway.transit_data.model.trips.TimepointPredictionBean;
 import org.onebusaway.transit_data.model.trips.TripBean;
 import org.onebusaway.transit_data.model.trips.TripDetailsBean;
 import org.onebusaway.transit_data.model.trips.TripDetailsInclusionBean;
@@ -311,6 +313,17 @@ public class TripStatusBeanServiceImpl implements TripDetailsBeanService {
           time, activeTripInstance, blockLocation.getVehicleId());
       if (!situations.isEmpty())
         bean.setSituations(situations);
+    }
+
+    if (blockLocation.getTimepointPredictions() != null && blockLocation.getTimepointPredictions().size() > 0) {
+      List<TimepointPredictionBean> timepointPredictions = new ArrayList<TimepointPredictionBean>();
+      for (TimepointPredictionRecord tpr: blockLocation.getTimepointPredictions()) {
+        TimepointPredictionBean tpb = new TimepointPredictionBean();
+        tpb.setTimepointId(tpr.getTimepointId().toString());
+        tpb.setTimepointPredictedTime(tpr.getTimepointPredictedTime());
+        timepointPredictions.add(tpb);
+      }
+      bean.setTimepointPredictions(timepointPredictions);
     }
 
     return bean;

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/BlockLocationServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/BlockLocationServiceImpl.java
@@ -550,6 +550,7 @@ public class BlockLocationServiceImpl implements BlockLocationService,
       location.setVehicleId(record.getVehicleId());
 
       List<TimepointPredictionRecord> timepointPredictions = record.getTimepointPredictions();
+      location.setTimepointPredictions(timepointPredictions);
       if (timepointPredictions != null && !timepointPredictions.isEmpty()) {
 
         SortedMap<Integer, Double> scheduleDeviations = new TreeMap<Integer, Double>();

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
@@ -48,6 +48,7 @@ import com.google.transit.realtime.GtfsRealtime.VehicleDescriptor;
 import com.google.transit.realtime.GtfsRealtime.VehiclePosition;
 import com.google.transit.realtime.GtfsRealtimeOneBusAway;
 import com.google.transit.realtime.GtfsRealtimeOneBusAway.OneBusAwayTripUpdate;
+import org.onebusaway.realtime.api.TimepointPredictionRecord;
 
 class GtfsRealtimeTripLibrary {
 
@@ -328,10 +329,13 @@ class GtfsRealtimeTripLibrary {
     int currentTime = (int) ((t - instance.getServiceDate()) / 1000);
     BestScheduleDeviation best = new BestScheduleDeviation();
 
+    List<TimepointPredictionRecord> timepointPredictions = new ArrayList<TimepointPredictionRecord>();
+
     for (BlockTripEntry blockTrip : blockTrips) {
       TripEntry trip = blockTrip.getTrip();
       AgencyAndId tripId = trip.getId();
       List<TripUpdate> updatesForTrip = tripUpdatesByTripId.get(tripId.getId());
+      
       if (updatesForTrip != null) {
         for (TripUpdate tripUpdate : updatesForTrip) {
 
@@ -364,6 +368,12 @@ class GtfsRealtimeTripLibrary {
             if (currentArrivalTime >= 0) {
               updateBestScheduleDeviation(currentTime,
                   stopTime.getArrivalTime(), currentArrivalTime, best);
+              
+              long timepointPredictedTime = instance.getServiceDate() + (currentArrivalTime * 1000L);
+              TimepointPredictionRecord tpr = new TimepointPredictionRecord();
+              tpr.setTimepointId(stopTime.getStop().getId());
+              tpr.setTimepointPredictedTime(timepointPredictedTime);
+              timepointPredictions.add(tpr);
             }
             int currentDepartureTime = computeDepartureTime(stopTime,
                 stopTimeUpdate, instance.getServiceDate());
@@ -381,6 +391,7 @@ class GtfsRealtimeTripLibrary {
     if (best.timestamp != 0) {
       record.setTimeOfRecord(best.timestamp);
     }
+    record.setTimepointPredictions(timepointPredictions);
   }
 
   private BlockStopTimeEntry getBlockStopTimeForStopTimeUpdate(

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/realtime/BlockLocation.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/realtime/BlockLocation.java
@@ -16,9 +16,11 @@
  */
 package org.onebusaway.transit_data_federation.services.realtime;
 
+import java.util.List;
 import org.onebusaway.geospatial.model.CoordinatePoint;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.realtime.api.EVehiclePhase;
+import org.onebusaway.realtime.api.TimepointPredictionRecord;
 import org.onebusaway.transit_data_federation.services.blocks.BlockInstance;
 import org.onebusaway.transit_data_federation.services.blocks.BlockTripInstance;
 import org.onebusaway.transit_data_federation.services.transit_graph.BlockStopTimeEntry;
@@ -97,6 +99,8 @@ public class BlockLocation {
   private ScheduleDeviationSamples scheduleDeviations = null;
 
   private AgencyAndId vehicleId;
+  
+  private List<TimepointPredictionRecord> timepointPredictions;
 
   public BlockLocation() {
 
@@ -436,6 +440,14 @@ public class BlockLocation {
 
   public void setVehicleId(AgencyAndId vehicleId) {
     this.vehicleId = vehicleId;
+  }
+
+  public List<TimepointPredictionRecord> getTimepointPredictions() {
+      return this.timepointPredictions;
+  }
+  
+  public void setTimepointPredictions(List<TimepointPredictionRecord> timepointPredictions) {
+      this.timepointPredictions = timepointPredictions;
   }
 
   @Override

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TimepointPredictionBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TimepointPredictionBean.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2013 Kurt Raschke <kurt@kurtraschke.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data.model.trips;
+
+import java.io.Serializable;
+
+public class TimepointPredictionBean implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private String timepointId;
+
+  private long timepointScheduledTime;
+
+  private long timepointPredictedTime;
+
+  public TimepointPredictionBean() {
+
+  }
+
+  public String getTimepointId() {
+    return timepointId;
+  }
+
+  public void setTimepointId(String timepointId) {
+    this.timepointId = timepointId;
+  }
+
+  public long getTimepointScheduledTime() {
+    return timepointScheduledTime;
+  }
+
+  public void setTimepointScheduledTime(long timepointScheduledTime) {
+    this.timepointScheduledTime = timepointScheduledTime;
+  }
+
+  public long getTimepointPredictedTime() {
+    return timepointPredictedTime;
+  }
+
+  public void setTimepointPredictedTime(long timepointPredictedTime) {
+    this.timepointPredictedTime = timepointPredictedTime;
+  }
+}

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TripStatusBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TripStatusBean.java
@@ -25,7 +25,7 @@ import org.onebusaway.transit_data.model.service_alerts.ServiceAlertBean;
 
 public final class TripStatusBean implements Serializable {
 
-  private static final long serialVersionUID = 2L;
+  private static final long serialVersionUID = 3L;
 
   /****
    * These are fields that we can supply from schedule data
@@ -89,6 +89,8 @@ public final class TripStatusBean implements Serializable {
   private String vehicleId;
 
   private List<ServiceAlertBean> situations;
+
+  private List<TimepointPredictionBean> timepointPredictions;
 
   public TripBean getActiveTrip() {
     return activeTrip;
@@ -360,5 +362,13 @@ public final class TripStatusBean implements Serializable {
 
   public void setSituations(List<ServiceAlertBean> situations) {
     this.situations = situations;
+  }
+
+  public List<TimepointPredictionBean> getTimepointPredictions() {
+    return timepointPredictions;
+  }
+
+  public void setTimepointPredictions(List<TimepointPredictionBean> timepointPredictions) {
+    this.timepointPredictions = timepointPredictions;
   }
 }


### PR DESCRIPTION
GTFS-realtime provides feed producers with the ability to supply multiple arrival/departure predictions per trip.  This can be used to enhance the quality of passenger information where it is known/predicted in advance (whether from manual input or a predictive algorithm) that a trip will further gain/lose time at future stops.

This PR adds support for preserving those per-stoptime predictions from GTFS-realtime sources and passing them through the TDS.  It also adds support for exposing those per-stoptime predictions in the GTFS-realtime exporters in the API webapp and TDS.

The API webapp and legacy Web interface do not make direct use of these per-stoptime predictions, but they can be used by the OBANYC SIRI API and Web UIs with a suitable `PredictionHelperService` (patch forthcoming).

This also provides the necessary infrastructure to preserve per-stoptime updates from SIRI VM sources, but that is not implemented here.

Finally, this PR augments the TDS GTFS-realtime export with a text-format Protocol Buffers debug mode, activated by calling the endpoint with `?debug=1`.
