### PR TITLE
Remove deprecated ServletContextFactoryBean bean definition.

### DIFF
--- a/onebusaway-webapp/src/main/resources/org/onebusaway/webapp/application-context-webapp.xml
+++ b/onebusaway-webapp/src/main/resources/org/onebusaway/webapp/application-context-webapp.xml
@@ -69,8 +69,6 @@
     </property>
   </bean>
 
-  <bean id="servletContext" class="org.springframework.web.context.support.ServletContextFactoryBean" />
-
   <bean id="geocoderImpl" class="org.onebusaway.geocoder.impl.DatabaseCachingGeocoderImpl" primary="true">
     <property name="geocoderService" ref="externalGeocoderImpl" />
   </bean>


### PR DESCRIPTION
This functionality is [now built-in to Spring](http://docs.spring.io/spring/docs/3.1.4.RELEASE/javadoc-api/org/springframework/web/context/support/ServletContextFactoryBean.html); keeping ServletContextFactoryBean in place inhibits loading under recent AspectJ versions with certain servlet containers.
