### PR TITLE
Improve federation of OBANYC TDS methods.

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/TrivialSchedulerHelperService.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/TrivialSchedulerHelperService.java
@@ -28,19 +28,19 @@ import org.springframework.stereotype.Component;
 public class TrivialSchedulerHelperService implements ScheduleHelperService {
 
 	@Override
-	public Boolean routeHasUpcomingScheduledService(String agencyId, long time, String routeId,
+	public Boolean routeHasUpcomingScheduledService(long time, String routeId,
 			String directionId) {
 		return null;
 	}
 
 	@Override
-	public Boolean stopHasUpcomingScheduledService(String agencyId, long time, String stopId,
+	public Boolean stopHasUpcomingScheduledService(long time, String stopId,
 			String routeId, String directionId) {
 		return null;
 	}
 
 	@Override
-	public List<String> getSearchSuggestions(String agencyId, String input) {
+	public List<String> getSearchSuggestions(String input) {
 		return null;
 	}
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/federated/TransitDataServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/federated/TransitDataServiceImpl.java
@@ -20,6 +20,7 @@ package org.onebusaway.transit_data_federation.impl.federated;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -646,8 +647,8 @@ class TransitDataServiceImpl implements TransitDataService {
   
 
   @Override
-  public String getActiveBundleId() {
-	  return _bundleManagementService.getActiveBundleId();
+  public List<String> getActiveBundleId() {
+	  return Collections.singletonList(_bundleManagementService.getActiveBundleId());
   }
 
   @Override
@@ -658,20 +659,20 @@ class TransitDataServiceImpl implements TransitDataService {
   }
 
   @Override
-  public Boolean routeHasUpcomingScheduledService(String agencyId, long time, String routeId,
+  public Boolean routeHasUpcomingScheduledService(long time, String routeId,
 		String directionId) {
-	  return _scheduleHelperService.routeHasUpcomingScheduledService(agencyId, time, routeId, directionId);
+	  return _scheduleHelperService.routeHasUpcomingScheduledService(time, routeId, directionId);
   }
 
   @Override
-  public Boolean stopHasUpcomingScheduledService(String agencyId, long time, String stopId,
+  public Boolean stopHasUpcomingScheduledService(long time, String stopId,
 		String routeId, String directionId) {
-	  return _scheduleHelperService.stopHasUpcomingScheduledService(agencyId, time, stopId, routeId, directionId);
+	  return _scheduleHelperService.stopHasUpcomingScheduledService(time, stopId, routeId, directionId);
   }
 
   @Override
-  public List<String> getSearchSuggestions(String agencyId, String input) {
-	  return _scheduleHelperService.getSearchSuggestions(agencyId, input);
+  public List<String> getSearchSuggestions(String input) {
+	  return _scheduleHelperService.getSearchSuggestions(input);
   }
 
   /****

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/ScheduleHelperService.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/ScheduleHelperService.java
@@ -22,13 +22,12 @@ public interface ScheduleHelperService {
 	/**
 	 * Check for scheduled service for the given route over the specified time period.  
 	 * That is, are any buses scheduled to visit this route in the next time period?
-	 * @param agencyId agency of the route
 	 * @param time period to check within
 	 * @param routeId of route to check
 	 * @param directionId of the route to check
 	 * @return True if scheduled service is found
 	 */
-	Boolean routeHasUpcomingScheduledService(String agencyId, long time, String routeId,
+	Boolean routeHasUpcomingScheduledService(long time, String routeId,
 			String directionId);
 
 	/**
@@ -42,17 +41,17 @@ public interface ScheduleHelperService {
 	 * @param directionId of the route to check
 	 * @return True if scheduled service is found
 	 */
-	Boolean stopHasUpcomingScheduledService(String agencyId, long time, String stopId,
+	Boolean stopHasUpcomingScheduledService(long time, String stopId,
 			String routeId, String directionId);
 
 	/**
-	 * Given the following partial input, lookup route names that "match".  The
+	 * Given the following partial input, lookup
+	 * route names/stop IDs/stop codes that "match".  The
 	 * definition of "match" is left to the implementor.  This method can be the
 	 * basis for autocompleting text in a user interface.
-	 * @param agencyId to constrain the search against; may be null.
 	 * @param input partial text representing a GTFS route short name.
 	 * @return a list of GTFS short names that may qualify.
 	 */
-	List<String> getSearchSuggestions(String agencyId, String input);
+	List<String> getSearchSuggestions(String input);
 
 }

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/services/TransitDataService.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/services/TransitDataService.java
@@ -563,34 +563,34 @@ public interface TransitDataService extends FederatedService {
    * Return an id for the currently loaded bundle.  Assumes bundle meta data is loaded.
    * @return a string representing the current bundle.
    */
-  @FederatedByAgencyIdMethod(propertyExpression = "agencyId")
-  public String getActiveBundleId();
+  @FederatedByAggregateMethod
+  public List<String> getActiveBundleId();
 
   /**
    * Retrieve a list of time predictions for the given trip as represented by the TripStatusBean.
    * @param tripStatus the query parameters of the trip
    * @return a list of TimepointPredictionRecords.
    */
-  @FederatedByAgencyIdMethod
+  @FederatedByEntityIdMethod(propertyExpression="tripStatus.vehicleId")
   public List<TimepointPredictionRecord> getPredictionRecordsForTrip(String agencyId, TripStatusBean tripStatus);
   
   /**
    * Check to see if scheduled service is expected.
    */
-  @FederatedByAgencyIdMethod
-  public Boolean routeHasUpcomingScheduledService(String agencyId, long time, String routeId, String directionId);
+  @FederatedByEntityIdMethod(propertyExpression="routeId")
+  public Boolean routeHasUpcomingScheduledService(long time, String routeId, String directionId);
 
   /**
    * Check to see if scheduled service is expected.
    */
-  @FederatedByAgencyIdMethod
-  public Boolean stopHasUpcomingScheduledService(String agencyId, long time, String stopId, String routeId, String directionId);
+  @FederatedByEntityIdMethod(propertyExpression="stopId")
+  public Boolean stopHasUpcomingScheduledService(long time, String stopId, String routeId, String directionId);
 
   /**
    * Given search string input, match against GTFS route short names and return a list of 
    * potential matches. 
    */
-  @FederatedByAgencyIdMethod
-  public List<String> getSearchSuggestions(String agencyId, String input);
+  @FederatedByAggregateMethod
+  public List<String> getSearchSuggestions(String input);
 
 }


### PR DESCRIPTION
The OBANYC `NycTransitDataService` methods were folded into the core `TransitDataService` in onebusaway/onebusaway-application-modules@4501b66c7410b2909a75b1091684aa2fda440d7b.

This PR is to improve the federation annotations on those methods (and in a few cases the method signatures as well).  For single-TDS deployments without federation, these changes would have no impact, and the new method signatures are in fact just a return to [the method signatures formerly used in `NycTransitDataService`](https://github.com/camsys/onebusaway-nyc/blob/4553b7dbb872e2db3290a8f598e008feea665871/onebusaway-nyc-transit-data/src/main/java/org/onebusaway/nyc/transit_data/services/NycTransitDataService.java).

The specific changes and rationales are as follows:
- `getActiveBundleId`: The active bundle ID is a property of an instance, not a specific agency.  The most likely use case for a consumer in the federated case is to determine the bundle IDs of all of the instances backing the federation server.  Thus the `FederatedByAggregateMethod` annotation is used.  In this PR a `List<String>` is used, but that could be replaced with `Map<String, String>` if it were desired to have (instance ID, active bundle ID) tuples.
- `getPredictionRecordsForTrip`, `routeHasUpcomingScheduledService`, `stopHasUpcomingScheduledService`: An explicit 'agencyId' parameter is not necessary, because `FederatedByEntityIdMethod` can extract the agency ID from a parameter or even a property of a parameter.
- `getSearchSuggestions`: As with `getActiveBundleId`, partition by agency ID doesn't really make sense; logically a consumer of a federated instance is going to want to get search suggestions aggregated from all of the TDS instances backing the federation server.  As the return type of `getSearchSuggestions` is `List<String>`, `FederatedByAggregateMethod` is a drop-in here.

This will also have some impact on camsys/onebusaway-nyc, following the work done in camsys/onebusaway-nyc@4ec143f375fd07dd7cc22b452e913a926528b3db.
