### PR TITLE
Prefer time field in a GTFS-realtime StopTimeEvent.

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
@@ -449,19 +449,21 @@ class GtfsRealtimeTripLibrary {
     long t = currentTime();
     if (stopTimeUpdate.hasArrival()) {
       StopTimeEvent arrival = stopTimeUpdate.getArrival();
+      if (arrival.hasTime()) {
+        return (int) (arrival.getTime() - serviceDate / 1000);
+      }
       if (arrival.hasDelay()) {
         return (int) ((t - serviceDate) / 1000 - arrival.getDelay());
       }
-      if (arrival.hasTime())
-        return (int) (arrival.getTime() - serviceDate / 1000);
     }
     if (stopTimeUpdate.hasDeparture()) {
       StopTimeEvent departure = stopTimeUpdate.getDeparture();
+      if (departure.hasTime()) {
+        return (int) (departure.getTime() - serviceDate / 1000);
+      }
       if (departure.hasDelay()) {
         return (int) ((t - serviceDate) / 1000 - departure.getDelay());
       }
-      if (departure.hasTime())
-        return (int) (departure.getTime() - serviceDate / 1000);
     }
     throw new IllegalStateException(
         "expected at least an arrival or departure time or delay for update: "


### PR DESCRIPTION
The [GTFS-realtime spec](https://developers.google.com/transit/gtfs-realtime/reference#StopTimeEvent) dictates that the `time` field should be preferred over `delay` if both are present, but OneBusAway's handling of the fields was inverted from the spec.

Discovered in onebusaway/onebusaway-application-modules#78.
