### PR TITLE
Update onebusaway-probablecalls version.

### DIFF
--- a/onebusaway-phone/pom.xml
+++ b/onebusaway-phone/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.onebusaway</groupId>
             <artifactId>onebusaway-probablecalls</artifactId>
-            <version>1.0.5</version>
+            <version>1.0.6</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.opensymphony</groupId>


### PR DESCRIPTION
This completes the fix for the DTD location issue first addressed in #95 now that a new `onebusaway-probablecalls` version has been released.
