### PR TITLE
Modularize distance-along-shape assignment

### DIFF
--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/impl/DistanceBasedStopToShapeMatchingServiceImpl.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/impl/DistanceBasedStopToShapeMatchingServiceImpl.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright (C) 2014 Kurt Raschke <kurt@kurtraschke.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation.bundle.impl;
+
+import org.onebusaway.transit_data_federation.bundle.services.StopToShapeMatchingService;
+import org.onebusaway.transit_data_federation.bundle.utilities.IndexedLine;
+import org.onebusaway.transit_data_federation.impl.transit_graph.StopTimeEntryImpl;
+import org.onebusaway.transit_data_federation.model.ShapePoints;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * Distance-based method for generating distance-along-trip values which makes
+ * use of shape_dist_traveled values.
+ *
+ * Will fail if shapes are not present, or if shapes or stop times are lacking
+ * shape_dist_traveled values.
+ *
+ */
+public class DistanceBasedStopToShapeMatchingServiceImpl implements StopToShapeMatchingService {
+
+  private final Logger _log = LoggerFactory.getLogger(DistanceBasedStopToShapeMatchingServiceImpl.class);
+
+  @Override
+  public void ensureStopTimesHaveShapeDistanceTraveledSet(List<StopTimeEntryImpl> stopTimes,
+          ShapePoints shapePoints, List<Double> stopTimeDistances) {
+
+    if (shapePoints == null || stopTimeDistances == null) {
+      throw new StopToShapeMatcherStateException(this.getClass().getName()
+              + " requires that shapePoints be non-null and stopTimeDistances be non-null");
+    }
+
+    IndexedLine il = new IndexedLine();
+
+    for (int i = 0; i < shapePoints.getSize(); i++) {
+      if (i > 0 && shapePoints.getDistTraveledForIndex(i) <= shapePoints.getDistTraveledForIndex(i - 1)) {
+        throw new StopToShapeMatcherStateException("Shape point distances went backwards: from "
+                + shapePoints.getDistTraveledForIndex(i - 1) + " to " + shapePoints.getDistTraveledForIndex(i));
+      }
+
+      il.addPoint(i, shapePoints.getDistTraveledForIndex(i), shapePoints.getPointForIndex(i));
+    }
+
+    double firstMeasure = stopTimeDistances.get(0);
+
+    ListIterator<StopTimeEntryImpl> stIterator = stopTimes.listIterator();
+
+    while (stIterator.hasNext()) {
+      int i = stIterator.nextIndex();
+      StopTimeEntryImpl st = stIterator.next();
+
+      double thisMeasure = stopTimeDistances.get(i);
+      double distance = il.interpolateDistance(firstMeasure, thisMeasure);
+      int index = il.interpolateIndex(thisMeasure);
+
+      st.setShapePointIndex(index);
+      st.setShapeDistTraveled(distance);
+    }
+  }
+}

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/impl/FallbackStopToShapeMatchingServiceImpl.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/impl/FallbackStopToShapeMatchingServiceImpl.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2014 Kurt Raschke <kurt@kurtraschke.com>
+ * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation.bundle.impl;
+
+import org.onebusaway.geospatial.model.CoordinatePoint;
+import org.onebusaway.geospatial.services.SphericalGeometryLibrary;
+import org.onebusaway.transit_data_federation.bundle.services.StopToShapeMatchingService;
+import org.onebusaway.transit_data_federation.impl.transit_graph.StopTimeEntryImpl;
+import org.onebusaway.transit_data_federation.model.ShapePoints;
+
+import java.util.List;
+
+/**
+ * Fallback method for generating distance-along-trip values;
+ * does not require (in fact, does not make use of) shape points.
+ *
+ */
+public class FallbackStopToShapeMatchingServiceImpl implements StopToShapeMatchingService {
+
+  @Override
+  public void ensureStopTimesHaveShapeDistanceTraveledSet(List<StopTimeEntryImpl> stopTimes,
+          ShapePoints shapePoints, List<Double> stopTimeDistances) {
+    double d = 0;
+    StopTimeEntryImpl prev = null;
+    for (StopTimeEntryImpl stopTime : stopTimes) {
+      if (prev != null) {
+        CoordinatePoint from = prev.getStop().getStopLocation();
+        CoordinatePoint to = stopTime.getStop().getStopLocation();
+        d += SphericalGeometryLibrary.distance(from, to);
+      }
+      stopTime.setShapeDistTraveled(d);
+      prev = stopTime;
+    }
+  }
+}

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/impl/HeuristicStopToShapeMatchingServiceImpl.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/impl/HeuristicStopToShapeMatchingServiceImpl.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2014 Kurt Raschke <kurt@kurtraschke.com>
+ * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation.bundle.impl;
+
+import org.onebusaway.geospatial.model.CoordinatePoint;
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.transit_data_federation.bundle.services.StopToShapeMatchingService;
+import org.onebusaway.transit_data_federation.bundle.tasks.transit_graph.DistanceAlongShapeLibrary;
+import org.onebusaway.transit_data_federation.impl.shapes.PointAndIndex;
+import org.onebusaway.transit_data_federation.impl.transit_graph.StopTimeEntryImpl;
+import org.onebusaway.transit_data_federation.model.ShapePoints;
+import org.onebusaway.transit_data_federation.services.transit_graph.StopEntry;
+import org.onebusaway.transit_data_federation.services.transit_graph.StopTimeEntry;
+import org.onebusaway.transit_data_federation.services.transit_graph.TripEntry;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+/**
+ * Conventional method for generating distance-along-trip values
+ * which attempts to map stops to the closest point along the shape,
+ * accounting for loops and other irregularities.
+ *
+ * Requires that shapes be present, and can fail if the shapes are sufficiently
+ * malformed or stops are too far from the corresponding shape points.
+ *
+ */
+public class HeuristicStopToShapeMatchingServiceImpl implements StopToShapeMatchingService {
+
+  private final Logger _log = LoggerFactory.getLogger(HeuristicStopToShapeMatchingServiceImpl.class);
+  private DistanceAlongShapeLibrary _distanceAlongShapeLibrary;
+
+  @Autowired
+  public void setDistanceAlongShapeLibrary(
+          DistanceAlongShapeLibrary distanceAlongShapeLibrary) {
+    _distanceAlongShapeLibrary = distanceAlongShapeLibrary;
+  }
+
+  @Override
+  public void ensureStopTimesHaveShapeDistanceTraveledSet(List<StopTimeEntryImpl> stopTimes,
+          ShapePoints shapePoints, List<Double> stopTimeDistances) {
+
+    if (shapePoints == null) {
+      throw new StopToShapeMatcherStateException(this.getClass().getName() + " requires that shapePoints be non-null");
+    }
+
+    try {
+      /*
+       * Zero out and then reset the shape distance traveled values,
+       * as stop-to-shape matching in DistanceAlongShapeLibrary
+       * depends on OBA having set them such that the first point is at
+       * zero and the distances are in meters.
+       */
+      shapePoints.setDistTraveled(new double[shapePoints.getSize()]);
+      shapePoints.ensureDistTraveled();
+
+      PointAndIndex[] stopTimePoints = _distanceAlongShapeLibrary.getDistancesAlongShape(
+              shapePoints, stopTimes);
+      for (int i = 0; i < stopTimePoints.length; i++) {
+        PointAndIndex pindex = stopTimePoints[i];
+        StopTimeEntryImpl stopTime = stopTimes.get(i);
+        stopTime.setShapePointIndex(pindex.index);
+        stopTime.setShapeDistTraveled(pindex.distanceAlongShape);
+      }
+    } catch (DistanceAlongShapeLibrary.StopIsTooFarFromShapeException ex) {
+      StopTimeEntry stopTime = ex.getStopTime();
+      TripEntry trip = stopTime.getTrip();
+      StopEntry stop = stopTime.getStop();
+      AgencyAndId shapeId = trip.getShapeId();
+      CoordinatePoint point = ex.getPoint();
+      PointAndIndex pindex = ex.getPointAndIndex();
+
+      _log.warn("Stop is too far from shape: trip=" + trip.getId() + " stop="
+              + stop.getId() + " stopLat=" + stop.getStopLat() + " stopLon="
+              + stop.getStopLon() + " shapeId=" + shapeId + " shapePoint="
+              + point + " index=" + pindex.index + " distance="
+              + pindex.distanceFromTarget);
+
+      throw new StopToShapeMatchingException(ex);
+    } catch (DistanceAlongShapeLibrary.DistanceAlongShapeException ex) {
+      _log.warn(
+              "InvalidStopToShapeMappingException thrown; for more information on errors of this kind, see:\n"
+              + "  https://github.com/OneBusAway/onebusaway-application-modules/wiki/Stop-to-Shape-Matching", ex);
+      throw new StopToShapeMatchingException(ex);
+    }
+  }
+}

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/impl/MultiStopToShapeMatchingServiceImpl.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/impl/MultiStopToShapeMatchingServiceImpl.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2014 Kurt Raschke <kurt@kurtraschke.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation.bundle.impl;
+
+import org.onebusaway.transit_data_federation.bundle.services.StopToShapeMatchingService;
+import org.onebusaway.transit_data_federation.impl.transit_graph.StopTimeEntryImpl;
+import org.onebusaway.transit_data_federation.model.ShapePoints;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ *
+ * @author kurt
+ */
+public class MultiStopToShapeMatchingServiceImpl implements StopToShapeMatchingService {
+
+  private final Logger _log = LoggerFactory.getLogger(MultiStopToShapeMatchingServiceImpl.class);
+  private List<StopToShapeMatchingService> _matchingServiceImplementations;
+
+  public MultiStopToShapeMatchingServiceImpl() {
+
+  }
+
+  public void setMatchingServiceImplementations(List<StopToShapeMatchingService> matchingServiceImplementations) {
+    _matchingServiceImplementations = matchingServiceImplementations;
+  }
+
+  @Override
+  public void ensureStopTimesHaveShapeDistanceTraveledSet(List<StopTimeEntryImpl> stopTimes,
+          ShapePoints shapePoints, List<Double> stopTimeDistances) {
+
+    List<Double> workingStopTimeDistances = (stopTimeDistances != null) ? Collections.unmodifiableList(stopTimeDistances) : null;
+
+    for (StopToShapeMatchingService matchingServiceImplementation : _matchingServiceImplementations) {
+
+      List<StopTimeEntryImpl> workingStopTimes = new ArrayList<StopTimeEntryImpl>();
+      for (StopTimeEntryImpl ste: stopTimes) {
+        workingStopTimes.add(new StopTimeEntryImpl(ste));
+      }
+
+      ShapePoints workingShapePoints = (shapePoints != null) ? new ShapePoints(shapePoints) : null;
+
+      try {
+        matchingServiceImplementation.ensureStopTimesHaveShapeDistanceTraveledSet(workingStopTimes, workingShapePoints, workingStopTimeDistances);
+      } catch (StopToShapeMatcherStateException ex) {
+        _log.info("Matching service " + matchingServiceImplementation.getClass().getName() + " unable to run: {}", ex.getMessage());
+        continue;
+      } catch (Exception ex) {
+        _log.warn("Matching service " + matchingServiceImplementation.getClass().getName() + " failed with exception", ex);
+        continue;
+      }
+
+      stopTimes.clear();
+      stopTimes.addAll(workingStopTimes);
+      return;
+    }
+
+    throw new IllegalStateException("No stop-to-shape matching service implementation completed successfully.");
+  }
+}

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/services/StopToShapeMatchingService.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/services/StopToShapeMatchingService.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright (C) 2014 Kurt Raschke <kurt@kurtraschke.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation.bundle.services;
+
+import org.onebusaway.transit_data_federation.impl.transit_graph.StopTimeEntryImpl;
+import org.onebusaway.transit_data_federation.model.ShapePoints;
+
+import java.util.List;
+
+/**
+ *
+ * @author kurt
+ */
+public interface StopToShapeMatchingService {
+
+  public void ensureStopTimesHaveShapeDistanceTraveledSet(List<StopTimeEntryImpl> stopTimes,
+          ShapePoints shapePoints,
+          List<Double> stopTimeDistances);
+
+  public class StopToShapeMatchingException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StopToShapeMatchingException(String message) {
+      super(message);
+    }
+
+    public StopToShapeMatchingException(Throwable cause) {
+      super(cause);
+    }
+  }
+
+  public class StopToShapeMatcherStateException extends StopToShapeMatchingException {
+
+    private static final long serialVersionUID = 1L;
+
+    public StopToShapeMatcherStateException(String message) {
+      super(message);
+    }
+  }
+}

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/ShapePointHelper.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/ShapePointHelper.java
@@ -69,6 +69,9 @@ public class ShapePointHelper {
     for (ShapePoint shapePoint : shapePoints) {
       lat[i] = shapePoint.getLat();
       lon[i] = shapePoint.getLon();
+      if (shapePoint.isDistTraveledSet()) {
+        distTraveled[i] = shapePoint.getDistTraveled();
+      }
       i++;
     }
 

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/DistanceAlongShapeLibrary.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/DistanceAlongShapeLibrary.java
@@ -132,6 +132,8 @@ public class DistanceAlongShapeLibrary {
     List<PointAndIndex> bestAssignment = computeBestAssignment(shapePoints,
         stopTimes, possibleAssignments, projection, projectedShapePoints);
 
+    double last = Double.NEGATIVE_INFINITY;
+    
     for (int i = 0; i < stopTimePoints.length; i++) {
       PointAndIndex pindex = bestAssignment.get(i);
       if (pindex.distanceAlongShape > maxDistanceTraveled) {
@@ -142,6 +144,11 @@ public class DistanceAlongShapeLibrary {
         double d = stopPoint.getDistance(point);
         pindex = new PointAndIndex(point, index, d, maxDistanceTraveled);
       }
+      
+      if (last > pindex.distanceAlongShape) {
+        constructError(shapePoints, stopTimes, possibleAssignments, projection);
+      }
+      last = pindex.distanceAlongShape;
       stopTimePoints[i] = pindex;
     }
     return stopTimePoints;
@@ -255,7 +262,7 @@ public class DistanceAlongShapeLibrary {
         projection, projectedShapePoints);
 
     int startIndex = 0;
-    int assingmentCount = 1;
+    int assignmentCount = 1;
 
     /**
      * We iterate over each stop, examining its possible assignments. If we find
@@ -273,7 +280,7 @@ public class DistanceAlongShapeLibrary {
 
       boolean hasRegion = index > startIndex;
       boolean hasSingleAssignmentFollowingMultipleAssignments = count == 1
-          && assingmentCount > 1;
+          && assignmentCount > 1;
       boolean hasMultipleAssignmentsAndLastPoint = count > 1
           && index == possibleAssignments.size() - 1;
 
@@ -298,12 +305,12 @@ public class DistanceAlongShapeLibrary {
       }
       if (count == 1) {
         startIndex = index;
-        assingmentCount = 1;
+        assignmentCount = 1;
       } else {
-        assingmentCount *= count;
-        if (assingmentCount > _maximumNumberOfPotentialAssignments) {
+        assignmentCount *= count;
+        if (assignmentCount > _maximumNumberOfPotentialAssignments) {
           constructErrorForPotentialAssignmentCount(shapePoints, stopTimes,
-              assingmentCount);
+              assignmentCount);
         }
       }
     }

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopTimeEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopTimeEntriesFactory.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
@@ -39,13 +40,10 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.ListIterator;
-
-
 @Component
 public class StopTimeEntriesFactory {
 
-  private final Logger _log = LoggerFactory.getLogger(StopTimeEntriesFactory.class);
+  private Logger _log = LoggerFactory.getLogger(StopTimeEntriesFactory.class);
 
   private StopToShapeMatchingService _matchingService;
 
@@ -89,7 +87,6 @@ public class StopTimeEntriesFactory {
         if (st.getShapeDistTraveled() > 0) {
           distancesNonZero = true;
         }
-
       } else {
         stopTimeDistances.add(0.0);
       }

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/TripEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/TripEntriesFactory.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.TimeZone;
 
-import org.onebusaway.container.ConfigurationParameter;
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.StopTime;
@@ -37,6 +36,7 @@ import org.onebusaway.transit_data_federation.impl.transit_graph.TripEntryImpl;
 import org.onebusaway.transit_data_federation.model.ShapePoints;
 import org.onebusaway.transit_data_federation.services.transit_graph.StopTimeEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.TripEntry;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -54,8 +54,6 @@ public class TripEntriesFactory {
   private StopTimeEntriesFactory _stopTimeEntriesFactory;
 
   private ShapePointHelper _shapePointsHelper;
-
-  private boolean _throwExceptionOnInvalidStopToShapeMappingException = true;
 
   @Autowired
   public void setUniqueService(UniqueService uniqueService) {
@@ -76,20 +74,6 @@ public class TripEntriesFactory {
   public void setStopTimeEntriesFactory(
       StopTimeEntriesFactory stopTimeEntriesFactory) {
     _stopTimeEntriesFactory = stopTimeEntriesFactory;
-  }
-
-  /**
-   * By default, we throw an exception when an invalid stop-to-shape mapping is
-   * found for a GTFS feed. Override that behavior by setting this parameter to
-   * false.
-   * 
-   * @param throwExceptionOnInvalidStopToShapeMappingException when true, an
-   *          exception is thrown on invalid stop-to-shape mappings
-   */
-  @ConfigurationParameter
-  public void setThrowExceptionOnInvalidStopToShapeMappingException(
-      boolean throwExceptionOnInvalidStopToShapeMappingException) {
-    _throwExceptionOnInvalidStopToShapeMappingException = throwExceptionOnInvalidStopToShapeMappingException;
   }
 
   public void processTrips(TransitGraphImpl graph) {
@@ -123,15 +107,6 @@ public class TripEntriesFactory {
 
       tripEntries.trimToSize();
       routeEntry.setTrips(tripEntries);
-    }
-
-    if (_stopTimeEntriesFactory.getInvalidStopToShapeMappingExceptionCount() > 0
-        && _throwExceptionOnInvalidStopToShapeMappingException) {
-      throw new IllegalStateException(
-          "Multiple instances of InvalidStopToShapeMappingException thrown: count="
-              + _stopTimeEntriesFactory.getInvalidStopToShapeMappingExceptionCount()
-              + ".  For more information on errors of this kind, see:\n"
-              + "  https://github.com/OneBusAway/onebusaway-application-modules/wiki/Stop-to-Shape-Matching");
     }
 
     graph.refreshTripMapping();

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/utilities/IndexedLine.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/utilities/IndexedLine.java
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2014 Kurt Raschke <kurt@kurtraschke.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation.bundle.utilities;
+
+import org.onebusaway.collections.tuple.Pair;
+import org.onebusaway.collections.tuple.Tuples;
+import org.onebusaway.geospatial.model.CoordinatePoint;
+import org.onebusaway.geospatial.services.SphericalGeometryLibrary;
+import org.onebusaway.utility.InterpolationLibrary;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
+/**
+ * Class for computing distances (in meters) between arbitrary points along a
+ * line, where the points defining the line are associated with distances in
+ * some arbitrary unit, and the points to be measured are identified in the same
+ * unit.
+ *
+ */
+public class IndexedLine {
+
+  private final Logger _log = LoggerFactory.getLogger(IndexedLine.class);
+
+  private final NavigableMap<Double, Point> _distanceToPointMap = new TreeMap<Double, Point>();
+  private final NavigableMap<Integer, Point> _indexToPointMap = new TreeMap<Integer, Point>();
+
+  public IndexedLine() {
+
+  }
+
+  public void addPoint(int index, double distance, CoordinatePoint point) {
+    Point p = new Point(index, distance, point);
+    _distanceToPointMap.put(p.getDistance(), p);
+    _indexToPointMap.put(p.getIndex(), p);
+  }
+
+  public int interpolateIndex(double measure) {
+    Pair<Point> neighborPoints = closestNeighbors(measure);
+
+    if (neighborPoints.isReflexive()) {
+      return neighborPoints.getFirst().getIndex();
+    }
+
+    double fraction = ((measure - neighborPoints.getFirst().getDistance()) / (neighborPoints.getSecond().getDistance() - neighborPoints.getFirst().getDistance()));
+
+    return ((fraction >= 0.5) ? neighborPoints.getSecond().getIndex() : neighborPoints.getFirst().getIndex());
+
+  }
+
+  public double interpolateDistance(double measureOne, double measureTwo) {
+    List<CoordinatePoint> points = new ArrayList<CoordinatePoint>();
+
+    Pair<Point> firstPointNeighbors = closestNeighbors(measureOne);
+    Pair<Point> lastPointNeighbors = closestNeighbors(measureTwo);
+
+    CoordinatePoint firstPoint = interpolatePoint(firstPointNeighbors, measureOne);
+
+    points.add(firstPoint);
+
+    for (Point p : _distanceToPointMap.subMap(measureOne, false, measureTwo, false).values()) {
+      points.add(p.getPoint());
+    }
+
+    CoordinatePoint lastPoint = interpolatePoint(lastPointNeighbors, measureTwo);
+    points.add(lastPoint);
+
+    return sumDistance(points);
+  }
+
+  private Pair<Point> closestNeighbors(double measure) {
+    Map.Entry<Double, Point> e1 = _distanceToPointMap.floorEntry(measure);
+    Map.Entry<Double, Point> e2 = _distanceToPointMap.ceilingEntry(measure);
+
+    /*
+     * If we're off the end of the shape at either end, then use the
+     * first two/last two points as appropriate and interpolate from there.
+     */
+    if (e1 == null) {
+      e1 = _distanceToPointMap.firstEntry();
+      e2 = _distanceToPointMap.higherEntry(e1.getKey());
+    } else if (e2 == null) {
+      e2 = _distanceToPointMap.lastEntry();
+      e1 = _distanceToPointMap.lowerEntry(e2.getKey());
+    }
+
+    return Tuples.pair(e1.getValue(), e2.getValue());
+  }
+
+  private CoordinatePoint interpolatePoint(Pair<Point> neighborPoints, double measure) {
+    if (neighborPoints.isReflexive()) {
+      return neighborPoints.getFirst().getPoint();
+    }
+
+    double fraction = (measure - neighborPoints.getFirst().getDistance()) / (neighborPoints.getSecond().getDistance() - neighborPoints.getFirst().getDistance());
+
+    CoordinatePoint pointOne = neighborPoints.getFirst().getPoint();
+    CoordinatePoint pointTwo = neighborPoints.getSecond().getPoint();
+
+    return new CoordinatePoint(InterpolationLibrary.interpolatePair(pointOne.getLat(), pointTwo.getLat(), fraction),
+            InterpolationLibrary.interpolatePair(pointOne.getLon(), pointTwo.getLon(), fraction));
+
+  }
+
+  private static double sumDistance(Iterable<CoordinatePoint> points) {
+    double d = 0;
+    CoordinatePoint last = null;
+    for (CoordinatePoint p : points) {
+      if (last != null) {
+        d += SphericalGeometryLibrary.distance(last, p);
+      }
+      last = p;
+    }
+
+    return d;
+  }
+
+  private class Point {
+
+    private int index;
+    private double distance;
+    private CoordinatePoint point;
+
+    public Point(int index, double distance, CoordinatePoint point) {
+      this.index = index;
+      this.distance = distance;
+      this.point = point;
+    }
+
+    public int getIndex() {
+      return index;
+    }
+
+    public void setIndex(int index) {
+      this.index = index;
+    }
+
+    public double getDistance() {
+      return distance;
+    }
+
+    public void setDistance(double distance) {
+      this.distance = distance;
+    }
+
+    public CoordinatePoint getPoint() {
+      return point;
+    }
+
+    public void setPoint(CoordinatePoint point) {
+      this.point = point;
+    }
+  }
+}

--- a/onebusaway-transit-data-federation-builder/src/main/resources/org/onebusaway/transit_data_federation/bundle/application-context-bundle-creator.xml
+++ b/onebusaway-transit-data-federation-builder/src/main/resources/org/onebusaway/transit_data_federation/bundle/application-context-bundle-creator.xml
@@ -38,6 +38,16 @@
 
   <bean id="modifications" class="org.onebusaway.transit_data_federation.model.modifications.Modifications" />
 
+  <bean id="stopToShapeMatchingService" class="org.onebusaway.transit_data_federation.bundle.impl.MultiStopToShapeMatchingServiceImpl">
+    <property name="matchingServiceImplementations">
+      <list>
+          <bean class="org.onebusaway.transit_data_federation.bundle.impl.DistanceBasedStopToShapeMatchingServiceImpl" />
+          <bean class="org.onebusaway.transit_data_federation.bundle.impl.HeuristicStopToShapeMatchingServiceImpl" />
+          <bean class="org.onebusaway.transit_data_federation.bundle.impl.FallbackStopToShapeMatchingServiceImpl" />
+      </list>
+    </property>
+  </bean>
+
   <context:component-scan base-package="org.onebusaway.transit_data_federation.bundle.tasks" />
 
   <!-- Task Definitions -->

--- a/onebusaway-transit-data-federation-builder/src/test/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopTimeEntriesFactoryTest.java
+++ b/onebusaway-transit-data-federation-builder/src/test/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopTimeEntriesFactoryTest.java
@@ -16,6 +16,7 @@
 package org.onebusaway.transit_data_federation.bundle.tasks.transit_graph;
 
 import static org.junit.Assert.assertEquals;
+
 import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.aid;
 import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.stop;
 import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.time;
@@ -25,13 +26,13 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.junit.Test;
+
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.Route;
 import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.StopTime;
 import org.onebusaway.gtfs.model.Trip;
-import org.onebusaway.transit_data_federation.bundle.tasks.transit_graph.DistanceAlongShapeLibrary;
-import org.onebusaway.transit_data_federation.bundle.tasks.transit_graph.StopTimeEntriesFactory;
+import org.onebusaway.transit_data_federation.bundle.impl.HeuristicStopToShapeMatchingServiceImpl;
 import org.onebusaway.transit_data_federation.impl.transit_graph.StopTimeEntryImpl;
 import org.onebusaway.transit_data_federation.impl.transit_graph.TransitGraphImpl;
 import org.onebusaway.transit_data_federation.impl.transit_graph.TripEntryImpl;
@@ -97,7 +98,9 @@ public class StopTimeEntriesFactoryTest {
     stC.setTrip(trip);
 
     StopTimeEntriesFactory factory = new StopTimeEntriesFactory();
-    factory.setDistanceAlongShapeLibrary(new DistanceAlongShapeLibrary());
+    HeuristicStopToShapeMatchingServiceImpl ms = new HeuristicStopToShapeMatchingServiceImpl();
+    ms.setDistanceAlongShapeLibrary(new DistanceAlongShapeLibrary());
+    factory.setStopToShapeMatchingService(ms);
 
     List<StopTime> stopTimes = Arrays.asList(stA, stB, stC);
 
@@ -136,7 +139,7 @@ public class StopTimeEntriesFactoryTest {
     assertEquals(1484.5, entry.getShapeDistTraveled(), 0.1);
     assertEquals(5 * 60, entry.getSlackTime());
   }
-  
+
   @Test
   public void testThreeInARowDuplicateRemoval() {
 
@@ -206,7 +209,9 @@ public class StopTimeEntriesFactoryTest {
     stD.setTrip(trip);
 
     StopTimeEntriesFactory factory = new StopTimeEntriesFactory();
-    factory.setDistanceAlongShapeLibrary(new DistanceAlongShapeLibrary());
+    HeuristicStopToShapeMatchingServiceImpl ms = new HeuristicStopToShapeMatchingServiceImpl();
+    ms.setDistanceAlongShapeLibrary(new DistanceAlongShapeLibrary());
+    factory.setStopToShapeMatchingService(ms);
 
     List<StopTime> stopTimes = Arrays.asList(stA, stB, stC, stD);
 
@@ -255,7 +260,7 @@ public class StopTimeEntriesFactoryTest {
     assertEquals(60 * 5, entry.getSlackTime());
 
   }
-  
+
   @Test
   public void test() {
 
@@ -311,7 +316,9 @@ public class StopTimeEntriesFactoryTest {
     stC.setTrip(trip);
 
     StopTimeEntriesFactory factory = new StopTimeEntriesFactory();
-    factory.setDistanceAlongShapeLibrary(new DistanceAlongShapeLibrary());
+    HeuristicStopToShapeMatchingServiceImpl ms = new HeuristicStopToShapeMatchingServiceImpl();
+    ms.setDistanceAlongShapeLibrary(new DistanceAlongShapeLibrary());
+    factory.setStopToShapeMatchingService(ms);
 
     List<StopTime> stopTimes = Arrays.asList(stA, stB, stC);
 

--- a/onebusaway-transit-data-federation-builder/src/test/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/TripEntriesFactoryTest.java
+++ b/onebusaway-transit-data-federation-builder/src/test/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/TripEntriesFactoryTest.java
@@ -18,6 +18,7 @@ package org.onebusaway.transit_data_federation.bundle.tasks.transit_graph;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+
 import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.aid;
 import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.lsid;
 import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.route;
@@ -29,6 +30,7 @@ import java.util.List;
 
 import org.junit.Test;
 import org.mockito.Mockito;
+
 import org.onebusaway.gtfs.model.Agency;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.Route;
@@ -36,6 +38,7 @@ import org.onebusaway.gtfs.model.Stop;
 import org.onebusaway.gtfs.model.StopTime;
 import org.onebusaway.gtfs.model.Trip;
 import org.onebusaway.gtfs.services.GtfsRelationalDao;
+import org.onebusaway.transit_data_federation.bundle.impl.HeuristicStopToShapeMatchingServiceImpl;
 import org.onebusaway.transit_data_federation.bundle.tasks.ShapePointHelper;
 import org.onebusaway.transit_data_federation.bundle.tasks.UniqueServiceImpl;
 import org.onebusaway.transit_data_federation.impl.transit_graph.RouteEntryImpl;
@@ -124,7 +127,9 @@ public class TripEntriesFactoryTest {
     factory.setUniqueService(new UniqueServiceImpl());
 
     StopTimeEntriesFactory stopTimeEntriesFactory = new StopTimeEntriesFactory();
-    stopTimeEntriesFactory.setDistanceAlongShapeLibrary(new DistanceAlongShapeLibrary());
+    HeuristicStopToShapeMatchingServiceImpl ms = new HeuristicStopToShapeMatchingServiceImpl();
+    ms.setDistanceAlongShapeLibrary(new DistanceAlongShapeLibrary());
+    stopTimeEntriesFactory.setStopToShapeMatchingService(ms);
 
     factory.setStopTimeEntriesFactory(stopTimeEntriesFactory);
 

--- a/onebusaway-transit-data-federation-builder/src/test/java/org/onebusaway/transit_data_federation/bundle/utilities/IndexedLineTest.java
+++ b/onebusaway-transit-data-federation-builder/src/test/java/org/onebusaway/transit_data_federation/bundle/utilities/IndexedLineTest.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2014 Kurt Raschke <kurt@kurtraschke.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation.bundle.utilities;
+
+import org.onebusaway.geospatial.model.CoordinatePoint;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ *
+ */
+public class IndexedLineTest {
+
+  @Test
+  public void testIndexedLine() {
+    IndexedLine il = new IndexedLine();
+
+    il.addPoint(10, 0, new CoordinatePoint(40.76430333537471, -73.97300844878706));
+    il.addPoint(20, 250.36, new CoordinatePoint(40.7639649335897, -73.97222185573889));
+    il.addPoint(30, 512.90, new CoordinatePoint(40.76359440983835, -73.97140902773853));
+
+    assertEquals(10, il.interpolateIndex(100));
+    assertEquals(20, il.interpolateIndex(245));
+    assertEquals(20, il.interpolateIndex(255));
+    assertEquals(30, il.interpolateIndex(500));
+
+    assertEquals(38.1, il.interpolateDistance(0, 125), 0.1);
+    assertEquals(114.3, il.interpolateDistance(0, 375), 0.5);
+    assertEquals(194.2, il.interpolateDistance(0, 637), 0.5);
+
+    assertEquals(156.1, il.interpolateDistance(125, 637), 0.5);
+  }
+}

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/StopTimeEntryImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/StopTimeEntryImpl.java
@@ -38,6 +38,24 @@ public class StopTimeEntryImpl implements StopTimeEntry, Serializable {
 
   private TripEntryImpl _trip;
 
+  public StopTimeEntryImpl() {
+
+  }
+
+  public StopTimeEntryImpl(StopTimeEntryImpl ste) {
+    _stopTimeId = ste.getId();
+    _arrivalTime = ste.getArrivalTime();
+    _departureTime = ste.getDepartureTime();
+    _sequence = ste.getSequence();
+    _dropOffType = ste.getDropOffType();
+    _pickupType = ste.getPickupType();
+    _shapePointIndex = ste.getShapePointIndex();
+    _shapeDistTraveled = ste.getShapeDistTraveled();
+    _accumulatedSlackTime = ste.getAccumulatedSlackTime();
+    _stop = ste.getStop();
+    _trip = ste.getTrip();
+  }
+
   public void setId(int id) {
     _stopTimeId = id;
   }
@@ -49,7 +67,7 @@ public class StopTimeEntryImpl implements StopTimeEntry, Serializable {
   public void setDepartureTime(int departureTime) {
     _departureTime = departureTime;
   }
-  
+
   public StopTimeEntryImpl setTime(int time) {
     _arrivalTime = time;
     _departureTime = time;
@@ -93,10 +111,9 @@ public class StopTimeEntryImpl implements StopTimeEntry, Serializable {
     _accumulatedSlackTime = accumulatedSlackTime;
   }
 
-  /****
+  /**
    * {@link StopTimeEntry} Interface
-   ****/
-
+   */
   @Override
   public int getId() {
     return _stopTimeId;
@@ -160,6 +177,6 @@ public class StopTimeEntryImpl implements StopTimeEntry, Serializable {
   @Override
   public String toString() {
     return "StopTimeEntryImpl(stop=" + _stop.getId() + " trip=" + _trip
-        + " arrival=" + _arrivalTime + " departure=" + _departureTime + ")";
+            + " arrival=" + _arrivalTime + " departure=" + _departureTime + ")";
   }
 }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/model/ShapePoints.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/model/ShapePoints.java
@@ -25,7 +25,7 @@ import java.io.Serializable;
 /**
  * A more memory efficient data structure for capturing a sequence of
  * {@link ShapePoint} objects
- * 
+ *
  * @author bdferris
  * @see ShapePoint
  */
@@ -40,6 +40,17 @@ public class ShapePoints implements Serializable {
   private double[] lons;
 
   private double[] distTraveled;
+
+  public ShapePoints() {
+
+  }
+
+  public ShapePoints(ShapePoints sp) {
+    shapeId = sp.getShapeId();
+    lats = sp.getLats().clone();
+    lons = sp.getLons().clone();
+    distTraveled = sp.getDistTraveled().clone();
+  }
 
   public int getSize() {
     return lats.length;
@@ -92,7 +103,7 @@ public class ShapePoints implements Serializable {
   public double getDistTraveledForIndex(int index) {
     return distTraveled[index];
   }
-  
+
   public CoordinatePoint getPointForIndex(int index) {
     return new CoordinatePoint(lats[index],lons[index]);
   }
@@ -115,7 +126,7 @@ public class ShapePoints implements Serializable {
       double curLat = lats[i];
       double curLon = lons[i];
       totalDistanceTraveled += SphericalGeometryLibrary.distance(prevLat,
-          prevLon, curLat, curLon);
+              prevLon, curLat, curLon);
       distTraveled[i] = totalDistanceTraveled;
       prevLat = curLat;
       prevLon = curLon;


### PR DESCRIPTION
Related to onebusaway/onebusaway-application-modules#100, this PR modularizes distance-along-shape computation and adds a new method which uses `shape_dist_traveled` values where available.

Configuration is done with a bean (so it can be overridden by users in their bundle-builder configuration):

```
  <bean id="stopToShapeMatchingService" class="org.onebusaway.transit_data_federation.bundle.impl.MultiStopToShapeMatchingServiceImpl">
    <property name="matchingServiceImplementations">
      <list>
          <bean class="org.onebusaway.transit_data_federation.bundle.impl.DistanceBasedStopToShapeMatchingServiceImpl" />
          <bean class="org.onebusaway.transit_data_federation.bundle.impl.HeuristicStopToShapeMatchingServiceImpl" />
          <bean class="org.onebusaway.transit_data_federation.bundle.impl.FallbackStopToShapeMatchingServiceImpl" />
      </list>
    </property>
  </bean>
```

By altering the bean configuration, users can disable the fallback option, such that if there are shape matching problems bundle building will fail, force use of `shape_dist_traveled` (or prohibit it), etc., plus introduce new stop-to-shape matching mechanisms simply by instantiating a bean.
