### PR TITLE
Prevent assignment of backwards-traveling distance-along-shape values.

### DIFF
--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/DistanceAlongShapeLibrary.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/DistanceAlongShapeLibrary.java
@@ -132,6 +132,8 @@ public class DistanceAlongShapeLibrary {
     List<PointAndIndex> bestAssignment = computeBestAssignment(shapePoints,
         stopTimes, possibleAssignments, projection, projectedShapePoints);
 
+    double last = Double.NEGATIVE_INFINITY;
+    
     for (int i = 0; i < stopTimePoints.length; i++) {
       PointAndIndex pindex = bestAssignment.get(i);
       if (pindex.distanceAlongShape > maxDistanceTraveled) {
@@ -142,6 +144,11 @@ public class DistanceAlongShapeLibrary {
         double d = stopPoint.getDistance(point);
         pindex = new PointAndIndex(point, index, d, maxDistanceTraveled);
       }
+      
+      if (last > pindex.distanceAlongShape) {
+        constructError(shapePoints, stopTimes, possibleAssignments, projection);
+      }
+      last = pindex.distanceAlongShape;
       stopTimePoints[i] = pindex;
     }
     return stopTimePoints;


### PR DESCRIPTION
Under [certain circumstances](https://groups.google.com/d/topic/onebusaway-developers/HvnZ8ig2aNw/discussion) `DistanceAlongShapeLibrary` can return a sequence of values which would result in (invalid) backwards travel along a shape.  While `DistanceAlongShapeLibrary` should ultimately be fixed to be more robust in those cases and produce correct assignments, as a stopgap solution this PR introduces a check such that backwards travel results in an exception being thrown.

If the user [intends to proceed anyway](https://github.com/OneBusAway/onebusaway-application-modules/wiki/Stop-to-Shape-Matching) they can run the bundle builder with `-P tripEntriesFactory.throwExceptionOnInvalidStopToShapeMappingException=false`, in which case distance-along-trip values (as well as interpolated stoptimes, where used) cannot be relied upon, as they will be based on the straight-line distances between stops, without the use of shape data.
