### PR TITLE
trip-details is failing for certain trip IDs

### DIFF
--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/TripDetailsAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/TripDetailsAction.java
@@ -15,6 +15,8 @@
  */
 package org.onebusaway.api.actions.api.where;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Date;
 
 import org.apache.struts2.rest.DefaultHttpHeaders;
@@ -60,8 +62,13 @@ public class TripDetailsAction extends ApiActionSupport {
   }
 
   @RequiredFieldValidator
-  public void setId(String id) {
-    _id = id;
+  public void setId(String id) { 
+    try {
+		_id = new URI(id).getPath();
+	} catch (URISyntaxException e) {
+		// TODO log a warning / error
+		_id = id;
+	}
   }
 
   public String getId() {


### PR DESCRIPTION
**TLDR version**
I am not sure that this is really the "correct" or "best" fix for this, but I have created the pull request in order to demonstrate where I believe the issue is and one possible solution for it.  See the full details for potentially better solutions.

The issue is that the iPhone app is generating the following URL when you try to view trip details for route 512 in the Puget Sound, which is returning nothing and causing the app to display an error.  The URL being generated is:
http://api.pugetsound.onebusaway.org/api/where/trip-details/29_14SEP-Weekday-510%2F512n-71.json?key=TEST&app_uid=A0684229-8411-487E-91F6-08EE2E413755&app_ver=1f56f03+&version=2&serviceDate=1421136000000&vehicleId=

The trip ID here is really "29_14SEP-Weekday-510/512n-71", but the "/" character has been URL encoded in the request.

I believe if the trip ID is simply decoded, then the response to the above URL should work.

**Full issue details**
A better solution might be to pre-process all properties being sent to ApiActionSupport instances to ensure that they are not URL encoded, however I am not familiar with the classes being used so it would take me much longer to implement this solution.

Another better solution might be to update the transit-data-federation-builder so that it filters out these potentially problematic characters in trip IDs.

Sound Transit route 512 has not been working on my iPhone.  I tried telling OneBusAway, but they didn't resolve the issue quickly enough for my liking so I decided to try and debug and fix the issue myself.

I tried spinning up my own web-server and ran the app in the simulator, but I couldn't reproduce the issue with the data I had (I downloaded the GTFS data from Sound Transit directly, generated a transit data bundle, started my server, pointed OneBusAway on the simulator to my server, and its route 512 works fine).

Then it occurred to me that the issue seemed specific to the API call being made for route 512 when pointing to the production API servers.  So I looked at it in more detail and determined that the issue could be the "/" in the trip ID.

*API repro*
Hit this URL:
http://api.pugetsound.onebusaway.org/api/where/trip-details/29_14SEP-Weekday-510%2F512n-71.json?key=TEST&app_uid=A0684229-8411-487E-91F6-08EE2E413755&app_ver=1f56f03+&version=2&serviceDate=1421136000000&vehicleId=

Expected result:
You get some JSON data back with the trip details

Actual result:
You get nothing.

*App Repro*
Install the App Store version of the OneBusAway app on an iPhone
Go to the Puget Sound region
Search for route 512
Choose any stop on the route and go to the stop details
Choose a 511 or 512 trip and go to the trip details
Try to "Show as map" or "Show on list"

Expected:
You see the 512 route or list

Actual:
View title is "Error connecting" and the view shows "Loading..." forever