### PR TITLE
Fix attachments to wiki entries in webapp

### DIFF
--- a/onebusaway-combined-webapp/src/main/assembly/full/WEB-INF/classes/struts.xml
+++ b/onebusaway-combined-webapp/src/main/assembly/full/WEB-INF/classes/struts.xml
@@ -37,7 +37,7 @@
   <constant name="struts.action.excludePattern" value="/services/.*" />
   <constant name="struts.enable.DynamicMethodInvocation" value="true" />
   
-  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\-]*" />
+  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\\-]*" />
 
   <bean type="com.opensymphony.xwork2.ActionProxyFactory" name="multi"
     class="org.onebusaway.presentation.impl.struts.MultiActionProxyFactory" />

--- a/onebusaway-combined-webapp/src/main/assembly/full/WEB-INF/classes/struts.xml
+++ b/onebusaway-combined-webapp/src/main/assembly/full/WEB-INF/classes/struts.xml
@@ -36,6 +36,8 @@
   <constant name="struts.action.extension" value="action,xhtml,,xml,json,csv,pb,pbtext" />
   <constant name="struts.action.excludePattern" value="/services/.*" />
   <constant name="struts.enable.DynamicMethodInvocation" value="true" />
+  
+  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\-]*" />
 
   <bean type="com.opensymphony.xwork2.ActionProxyFactory" name="multi"
     class="org.onebusaway.presentation.impl.struts.MultiActionProxyFactory" />

--- a/onebusaway-combined-webapp/src/main/assembly/ui-only/WEB-INF/classes/struts.xml
+++ b/onebusaway-combined-webapp/src/main/assembly/ui-only/WEB-INF/classes/struts.xml
@@ -37,7 +37,7 @@
   <constant name="struts.action.excludePattern" value="/services/.*" />
   <constant name="struts.enable.DynamicMethodInvocation" value="true" />
   
-  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\-]*" />
+  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\\-]*" />
 
   <bean type="com.opensymphony.xwork2.ActionProxyFactory" name="multi"
     class="org.onebusaway.presentation.impl.struts.MultiActionProxyFactory" />

--- a/onebusaway-combined-webapp/src/main/assembly/ui-only/WEB-INF/classes/struts.xml
+++ b/onebusaway-combined-webapp/src/main/assembly/ui-only/WEB-INF/classes/struts.xml
@@ -36,6 +36,8 @@
   <constant name="struts.action.extension" value="action,xhtml,,xml,json,csv,pb,pbtext" />
   <constant name="struts.action.excludePattern" value="/services/.*" />
   <constant name="struts.enable.DynamicMethodInvocation" value="true" />
+  
+  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\-]*" />
 
   <bean type="com.opensymphony.xwork2.ActionProxyFactory" name="multi"
     class="org.onebusaway.presentation.impl.struts.MultiActionProxyFactory" />

--- a/onebusaway-webapp/src/main/resources/struts.xml
+++ b/onebusaway-webapp/src/main/resources/struts.xml
@@ -28,6 +28,7 @@
   <constant name="struts.convention.action.checkImplementsAction" value="false" />
   <constant name="struts.action.excludePattern" value="/services/.*,/api/.*" />
   <constant name="struts.enable.DynamicMethodInvocation" value="true" />
+  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\-]*" />
 
   <include file="struts-onebusaway-webapp.xml"/>
 </struts>

--- a/onebusaway-webapp/src/main/resources/struts.xml
+++ b/onebusaway-webapp/src/main/resources/struts.xml
@@ -28,7 +28,7 @@
   <constant name="struts.convention.action.checkImplementsAction" value="false" />
   <constant name="struts.action.excludePattern" value="/services/.*,/api/.*" />
   <constant name="struts.enable.DynamicMethodInvocation" value="true" />
-  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\-]*" />
+  <constant name="struts.allowed.action.names" value="[a-zA-Z0-9._!@/\\-]*" />
 
   <include file="struts-onebusaway-webapp.xml"/>
 </struts>


### PR DESCRIPTION
Attachments to wiki entries (such as the images on the default homepage supplied with the quickstart) were not being served, with errors such as the following being logged:

`Feb 06, 2015 9:46:40 PM org.apache.struts2.dispatcher.mapper.DefaultActionMapper warn
WARNING: Action [Index@Logo.png!attachment] does not match allowed action names pattern [[a-zA-Z0-9._!/\-]*], cleaning it up!`

The default value for `struts.allowed.action.names` is `[a-zA-Z0-9._!/\-]*`; this PR sets it to `[a-zA-Z0-9._!@/\-]*` (adding `@`).