### PR TITLE
Fix support for TripUpdate.delay field in GtfsRealtimeTripLibrary

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
@@ -237,6 +237,10 @@ class GtfsRealtimeTripLibrary {
 
   private boolean hasDelayValue(TripUpdate tripUpdate) {
 
+    if (tripUpdate.hasDelay()) {
+      return true;
+    }
+
     if (tripUpdate.hasExtension(GtfsRealtimeOneBusAway.obaTripUpdate)) {
       OneBusAwayTripUpdate obaTripUpdate = tripUpdate.getExtension(GtfsRealtimeOneBusAway.obaTripUpdate);
       if (obaTripUpdate.hasDelay()) {


### PR DESCRIPTION
PR #119 added support for the `TripUpdate.delay` field in GTFS-realtime feeds.  Because `GtfsRealtimeTripLibrary.hasDelayValue()` was not updated to look for values in that field, the test in [`getTripUpdatesByBlockDescriptor`](https://github.com/OneBusAway/onebusaway-application-modules/blob/master/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java#L224) would erroneously discard updates which only contained a `TripUpdate.delay` value.