### PR TITLE
Added headers to update urls

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
@@ -169,7 +169,7 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
     _refreshInterval = refreshInterval;
   }
   
-  public void setHeadersMap(Map<String,String> headersMap){
+  public void setHeadersMap(Map<String,String> headersMap) {
 	  _headersMap = headersMap;
   }
   
@@ -380,15 +380,12 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
  * @param urlConnection
  * @return, the urlConnection with the headers set
  */
-  private void setHeadersToUrlConnection(URLConnection urlConnection)
-  {
-	  if(_headersMap!= null)
-	  {
-		  for(Map.Entry<String, String> headerEntry : _headersMap.entrySet())
-		  {
-			  urlConnection.setRequestProperty(headerEntry.getKey(), headerEntry.getValue());
-		  }
-	  }
+  private void setHeadersToUrlConnection(URLConnection urlConnection) {
+   if(_headersMap != null) {
+		for(Map.Entry<String, String> headerEntry : _headersMap.entrySet()) {
+		  urlConnection.setRequestProperty(headerEntry.getKey(), headerEntry.getValue());
+		}
+	}
   }
   /****
    *

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
@@ -90,7 +90,7 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
 
   private int _refreshInterval = 30;
   
-  private String _headers = "";
+  private Map<String,String> _headersMap;
   
   private Map _alertAgencyIdMap;
 
@@ -169,8 +169,8 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
     _refreshInterval = refreshInterval;
   }
   
-  public void setHeaders(String headers){
-	  _headers = headers;
+  public void setHeadersMap(Map<String,String> headersMap){
+	  _headersMap = headersMap;
   }
   
   public void setAlertAgencyIdMap(Map alertAgencyIdMap) {
@@ -382,17 +382,11 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
  */
   private void setHeadersToUrlConnection(URLConnection urlConnection)
   {
-	  if(_headers!= null && _headers != "")
+	  if(_headersMap!= null)
 	  {
-		  String[] headers = _headers.split(";");
-		  String headerCuts[];
-		  for(String header_value : headers)
+		  for(Map.Entry<String, String> headerEntry : _headersMap.entrySet())
 		  {
-			  headerCuts = header_value.split(":");
-			  if(headerCuts!= null && headerCuts.length == 2)
-			  {
-				  urlConnection.setRequestProperty(headerCuts[0], headerCuts[1]); 
-			  }
+			  urlConnection.setRequestProperty(headerEntry.getKey(), headerEntry.getValue());
 		  }
 	  }
   }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
@@ -170,7 +170,7 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
   }
   
   public void setHeadersMap(Map<String,String> headersMap) {
-	  _headersMap = headersMap;
+	_headersMap = headersMap;
   }
   
   public void setAlertAgencyIdMap(Map alertAgencyIdMap) {
@@ -381,8 +381,8 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
  * @return, the urlConnection with the headers set
  */
   private void setHeadersToUrlConnection(URLConnection urlConnection) {
-   if(_headersMap != null) {
-	  for(Map.Entry<String, String> headerEntry : _headersMap.entrySet()) {
+   if (_headersMap != null) {
+	  for (Map.Entry<String, String> headerEntry : _headersMap.entrySet()) {
 	    urlConnection.setRequestProperty(headerEntry.getKey(), headerEntry.getValue());
 	  }
 	}

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
@@ -382,9 +382,9 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
  */
   private void setHeadersToUrlConnection(URLConnection urlConnection) {
    if(_headersMap != null) {
-		for(Map.Entry<String, String> headerEntry : _headersMap.entrySet()) {
-		  urlConnection.setRequestProperty(headerEntry.getKey(), headerEntry.getValue());
-		}
+	  for(Map.Entry<String, String> headerEntry : _headersMap.entrySet()) {
+	    urlConnection.setRequestProperty(headerEntry.getKey(), headerEntry.getValue());
+	  }
 	}
   }
   /****

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
@@ -18,6 +18,7 @@ package org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.net.URLConnection;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Date;
@@ -88,6 +89,8 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
   private URL _alertsUrl;
 
   private int _refreshInterval = 30;
+  
+  private String _headers = "";
   
   private Map _alertAgencyIdMap;
 
@@ -164,6 +167,10 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
 
   public void setRefreshInterval(int refreshInterval) {
     _refreshInterval = refreshInterval;
+  }
+  
+  public void setHeaders(String headers){
+	  _headers = headers;
   }
   
   public void setAlertAgencyIdMap(Map alertAgencyIdMap) {
@@ -355,7 +362,9 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
    * @throws IOException
    */
   private FeedMessage readFeedFromUrl(URL url) throws IOException {
-    InputStream in = url.openStream();
+   URLConnection urlConnection = url.openConnection();
+   setHeadersToUrlConnection(urlConnection);
+   InputStream in = urlConnection.getInputStream();
     try {
       return FeedMessage.parseFrom(in, _registry);
     } finally {
@@ -366,7 +375,27 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
       }
     }
   }
-
+/**
+ * Set the headers to the urlConnection if any
+ * @param urlConnection
+ * @return, the urlConnection with the headers set
+ */
+  private void setHeadersToUrlConnection(URLConnection urlConnection)
+  {
+	  if(_headers!= null && _headers != "")
+	  {
+		  String[] headers = _headers.split(";");
+		  String headerCuts[];
+		  for(String header_value : headers)
+		  {
+			  headerCuts = header_value.split(":");
+			  if(headerCuts!= null && headerCuts.length == 2)
+			  {
+				  urlConnection.setRequestProperty(headerCuts[0], headerCuts[1]); 
+			  }
+		  }
+	  }
+  }
   /****
    *
    ****/


### PR DESCRIPTION
- Added a headers property to GtfsRealtimeSource class
- We can add header values through the data-source.xml file in
onebusaway-transit-data-federation-webapp/src/main/resources

Explanations:
I contribute to the TransitScreen project and we had to add the Metro
North Rail agency to get real time info. The problem is that we need to
set the Accept header to application/x-protobuf to get the proto file
for this agency (see
http://datamine.mta.info/MNR-Train-Time-feed-documentation). Without
setting it, we get an error running OBA: Error updating from
GTFS-realtime data sources. Protocol message end-group tag did not match
expected tag.

Setting the header fixes it.

So for this agency, we can set the headers in the data-sources.xml:
```<property name="headers" value="Accept:application/x-protobuf" />```

Let me know what you think or let me know if you have any question.