### PR TITLE
WIP - Fix #128 - More than one GTFS-rt TripUpdate per vehicle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java


### PR DESCRIPTION
As discussed in Issue https://github.com/OneBusAway/onebusaway-application-modules/issues/128, we were throwing out the older trip update. With this modification, now we don't overwrite the updates. 