### PR TITLE
Preserve per-stoptime predictions from GTFS-realtime updates.

### DIFF
--- a/onebusaway-transit-data-federation-webapp/src/main/java/org/onebusaway/transit_data_federation_webapp/controllers/gtfs_realtime/GtfsRealtimeController.java
+++ b/onebusaway-transit-data-federation-webapp/src/main/java/org/onebusaway/transit_data_federation_webapp/controllers/gtfs_realtime/GtfsRealtimeController.java
@@ -1,4 +1,5 @@
 /**
+ * Copyright (C) 2013 Kurt Raschke
  * Copyright (C) 2011 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,8 @@
 package org.onebusaway.transit_data_federation_webapp.controllers.gtfs_realtime;
 
 import java.io.IOException;
-import java.io.OutputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 import org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime.GtfsRealtimeService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,20 +38,32 @@ public class GtfsRealtimeController {
   }
 
   @RequestMapping(value = "/gtfs-realtime/trip-updates.action")
-  public void tripUpdates(OutputStream out) throws IOException {
+  public void tripUpdates(ServletRequest request, HttpServletResponse response) throws IOException {
     FeedMessage tripUpdates = _gtfsRealtimeService.getTripUpdates();
-    tripUpdates.writeTo(out);
+    render(request, response, tripUpdates);
   }
 
   @RequestMapping(value = "/gtfs-realtime/vehicle-positions.action")
-  public void vehiclePositions(OutputStream out) throws IOException {
+  public void vehiclePositions(ServletRequest request, HttpServletResponse response) throws IOException {
     FeedMessage vehiclePositions = _gtfsRealtimeService.getVehiclePositions();
-    vehiclePositions.writeTo(out);
+    render(request, response, vehiclePositions);
   }
 
   @RequestMapping(value = "/gtfs-realtime/alerts.action")
-  public void alerts(OutputStream out) throws IOException {
+  public void alerts(ServletRequest request, HttpServletResponse response) throws IOException {
     FeedMessage alerts = _gtfsRealtimeService.getAlerts();
-    alerts.writeTo(out);
+    render(request, response, alerts);
   }
+
+  private void render(ServletRequest request, HttpServletResponse response,
+          FeedMessage message) throws IOException {
+    if (request.getParameter("debug") != null) {
+      response.setContentType("text/plain");
+      response.getWriter().write(message.toString());
+    } else {
+      response.setContentType("application/x-google-protobuf");
+      message.writeTo(response.getOutputStream());
+   }
+  }
+
 }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/TripStatusBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/TripStatusBeanServiceImpl.java
@@ -22,11 +22,13 @@ import java.util.Map;
 
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.realtime.api.EVehiclePhase;
+import org.onebusaway.realtime.api.TimepointPredictionRecord;
 import org.onebusaway.transit_data.model.ListBean;
 import org.onebusaway.transit_data.model.StopBean;
 import org.onebusaway.transit_data.model.TripStopTimesBean;
 import org.onebusaway.transit_data.model.schedule.FrequencyBean;
 import org.onebusaway.transit_data.model.service_alerts.ServiceAlertBean;
+import org.onebusaway.transit_data.model.trips.TimepointPredictionBean;
 import org.onebusaway.transit_data.model.trips.TripBean;
 import org.onebusaway.transit_data.model.trips.TripDetailsBean;
 import org.onebusaway.transit_data.model.trips.TripDetailsInclusionBean;
@@ -321,6 +323,17 @@ public class TripStatusBeanServiceImpl implements TripDetailsBeanService {
           time, activeTripInstance, blockLocation.getVehicleId());
       if (!situations.isEmpty())
         bean.setSituations(situations);
+    }
+
+    if (blockLocation.getTimepointPredictions() != null && blockLocation.getTimepointPredictions().size() > 0) {
+      List<TimepointPredictionBean> timepointPredictions = new ArrayList<TimepointPredictionBean>();
+      for (TimepointPredictionRecord tpr: blockLocation.getTimepointPredictions()) {
+        TimepointPredictionBean tpb = new TimepointPredictionBean();
+        tpb.setTimepointId(tpr.getTimepointId().toString());
+        tpb.setTimepointPredictedTime(tpr.getTimepointPredictedTime());
+        timepointPredictions.add(tpb);
+      }
+      bean.setTimepointPredictions(timepointPredictions);
     }
 
     return bean;

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/BlockLocationServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/BlockLocationServiceImpl.java
@@ -550,6 +550,7 @@ public class BlockLocationServiceImpl implements BlockLocationService,
       location.setVehicleId(record.getVehicleId());
 
       List<TimepointPredictionRecord> timepointPredictions = record.getTimepointPredictions();
+      location.setTimepointPredictions(timepointPredictions);
       if (timepointPredictions != null && !timepointPredictions.isEmpty()) {
 
         SortedMap<Integer, Double> scheduleDeviations = new TreeMap<Integer, Double>();

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/realtime/BlockLocation.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/realtime/BlockLocation.java
@@ -16,9 +16,11 @@
  */
 package org.onebusaway.transit_data_federation.services.realtime;
 
+import java.util.List;
 import org.onebusaway.geospatial.model.CoordinatePoint;
 import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.realtime.api.EVehiclePhase;
+import org.onebusaway.realtime.api.TimepointPredictionRecord;
 import org.onebusaway.transit_data_federation.services.blocks.BlockInstance;
 import org.onebusaway.transit_data_federation.services.blocks.BlockTripInstance;
 import org.onebusaway.transit_data_federation.services.transit_graph.BlockStopTimeEntry;
@@ -101,6 +103,8 @@ public class BlockLocation {
   private ScheduleDeviationSamples scheduleDeviations = null;
 
   private AgencyAndId vehicleId;
+  
+  private List<TimepointPredictionRecord> timepointPredictions;
 
   public BlockLocation() {
 
@@ -456,6 +460,14 @@ public EVehiclePhase getPhase() {
 
   public void setVehicleId(AgencyAndId vehicleId) {
     this.vehicleId = vehicleId;
+  }
+
+  public List<TimepointPredictionRecord> getTimepointPredictions() {
+      return this.timepointPredictions;
+  }
+  
+  public void setTimepointPredictions(List<TimepointPredictionRecord> timepointPredictions) {
+      this.timepointPredictions = timepointPredictions;
   }
 
   @Override

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TimepointPredictionBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TimepointPredictionBean.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (C) 2013 Kurt Raschke <kurt@kurtraschke.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data.model.trips;
+
+import java.io.Serializable;
+
+public class TimepointPredictionBean implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private String timepointId;
+
+  private long timepointScheduledTime;
+
+  private long timepointPredictedTime;
+
+  public TimepointPredictionBean() {
+
+  }
+
+  public String getTimepointId() {
+    return timepointId;
+  }
+
+  public void setTimepointId(String timepointId) {
+    this.timepointId = timepointId;
+  }
+
+  public long getTimepointScheduledTime() {
+    return timepointScheduledTime;
+  }
+
+  public void setTimepointScheduledTime(long timepointScheduledTime) {
+    this.timepointScheduledTime = timepointScheduledTime;
+  }
+
+  public long getTimepointPredictedTime() {
+    return timepointPredictedTime;
+  }
+
+  public void setTimepointPredictedTime(long timepointPredictedTime) {
+    this.timepointPredictedTime = timepointPredictedTime;
+  }
+}

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TripStatusBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TripStatusBean.java
@@ -25,7 +25,7 @@ import org.onebusaway.transit_data.model.service_alerts.ServiceAlertBean;
 
 public final class TripStatusBean implements Serializable {
 
-  private static final long serialVersionUID = 2L;
+  private static final long serialVersionUID = 3L;
 
   /****
    * These are fields that we can supply from schedule data
@@ -96,6 +96,8 @@ public final class TripStatusBean implements Serializable {
   private String vehicleId;
 
   private List<ServiceAlertBean> situations;
+
+  private List<TimepointPredictionBean> timepointPredictions;
 
   public TripBean getActiveTrip() {
     return activeTrip;
@@ -392,5 +394,13 @@ public void setPreviousStopDistanceFromVehicle(
 
   public void setSituations(List<ServiceAlertBean> situations) {
     this.situations = situations;
+  }
+
+  public List<TimepointPredictionBean> getTimepointPredictions() {
+    return timepointPredictions;
+  }
+
+  public void setTimepointPredictions(List<TimepointPredictionBean> timepointPredictions) {
+    this.timepointPredictions = timepointPredictions;
   }
 }


### PR DESCRIPTION
This code was originally merged to `develop` in PR #78, but `develop` has diverged from `master` and the original patch no longer cleanly applies. This is PR #78, on top of `master` with merge conflicts addressed, to facilitate the further work being done in #127.
