### PR TITLE
Fix handling of GTFS-realtime updates with service date set

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeSource.java
@@ -210,6 +210,7 @@ public class GtfsRealtimeSource implements MonitoredDataSource {
     _tripsLibrary = new GtfsRealtimeTripLibrary();
     _tripsLibrary.setBlockCalendarService(_blockCalendarService);
     _tripsLibrary.setEntitySource(_entitySource);
+    _tripsLibrary.setAgencyService(_agencyService);
 
     _alertLibrary = new GtfsRealtimeAlertLibrary();
     _alertLibrary.setEntitySource(_entitySource);

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
@@ -23,6 +23,7 @@ import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.gtfs.model.calendar.ServiceDate;
 import org.onebusaway.gtfs.serialization.mappings.StopTimeFieldMappingFactory;
 import org.onebusaway.realtime.api.VehicleLocationRecord;
+import org.onebusaway.transit_data_federation.services.AgencyService;
 import org.onebusaway.transit_data_federation.services.blocks.BlockCalendarService;
 import org.onebusaway.transit_data_federation.services.blocks.BlockInstance;
 import org.onebusaway.transit_data_federation.services.transit_graph.BlockConfigurationEntry;
@@ -59,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.TimeZone;
 
 class GtfsRealtimeTripLibrary {
 
@@ -67,6 +69,8 @@ class GtfsRealtimeTripLibrary {
   private GtfsRealtimeEntitySource _entitySource;
 
   private BlockCalendarService _blockCalendarService;
+
+  private AgencyService _agencyService;
 
   /**
    * This is primarily here to assist with unit testing.
@@ -79,6 +83,10 @@ class GtfsRealtimeTripLibrary {
 
   public void setBlockCalendarService(BlockCalendarService blockCalendarService) {
     _blockCalendarService = blockCalendarService;
+  }
+
+  public void setAgencyService(AgencyService agencyService) {
+    _agencyService = agencyService;
   }
 
   public long getCurrentTime() {
@@ -398,8 +406,9 @@ class GtfsRealtimeTripLibrary {
     }
     
     if (serviceDate != null) {
-    	instance = _blockCalendarService.getBlockInstance(block.getId(),
-    			serviceDate.getAsDate().getTime());
+        TimeZone atz = _agencyService.getTimeZoneForAgencyId(block.getId().getAgencyId());
+        instance = _blockCalendarService.getBlockInstance(block.getId(),
+                        serviceDate.getAsDate(atz).getTime());
     	if (instance == null) {
     		_log.warn("block " + block.getId() + " does not exist on service date "
     				+ serviceDate);


### PR DESCRIPTION
Where a GTFS-realtime update has the service date set in its `TripDescriptor`, and the OBA server timezone does not match the agency timezone, `GtfsRealtimeTripLibrary` will fail to find the real-time trip's block, and will log messages such as the following:

`block WSF_1621104061513 does not exist on service date ServiceIdDate(2015-4-6)`

This at first defies troubleshooting, as the block does indeed exist on the specified service date--but internally the lookup is being performed with a Unix timestamp that does not correspond to the service date _in the agency's timezone_, thus the error.

The fix, implemented here, is to pass in an instance of `AgencyService` to `GtfsRealtimeTripLibrary` and use it to find the timezone for the block's agency, then use that when converting the service date to a Unix timestamp.
