### PR TITLE
Fix per-stop predictions (#127, #138, and #139)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: java

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyAction.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2013 Google, Inc.
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +32,7 @@ import org.onebusaway.transit_data.model.trips.TimepointPredictionBean;
 
 public class TripUpdatesForAgencyAction extends GtfsRealtimeActionSupport {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   @Override
   protected void fillFeedMessage(FeedMessage.Builder feed, String agencyId,
@@ -64,7 +65,14 @@ public class TripUpdatesForAgencyAction extends GtfsRealtimeActionSupport {
           TripUpdate.StopTimeUpdate.Builder stopTimeUpdate = tripUpdate.addStopTimeUpdateBuilder();
           stopTimeUpdate.setStopId(normalizeId(timepointPrediction.getTimepointId()));
           TripUpdate.StopTimeEvent.Builder arrival = stopTimeUpdate.getArrivalBuilder();
-          arrival.setTime(timepointPrediction.getTimepointPredictedTime());
+          if (timepointPrediction.getTimepointPredictedArrivalTime() != -1) {
+            arrival.setTime(timepointPrediction.getTimepointPredictedArrivalTime());
+          }
+  
+          TripUpdate.StopTimeEvent.Builder departure = stopTimeUpdate.getDepartureBuilder();
+          if (timepointPrediction.getTimepointPredictedDepartureTime() != -1) {
+            departure.setTime(timepointPrediction.getTimepointPredictedDepartureTime());
+          }
         }
         
         tripUpdate.setTimestamp(vehicle.getLastUpdateTime() / 1000);

--- a/onebusaway-core/src/main/java/org/onebusaway/utility/EInRangeStrategy.java
+++ b/onebusaway-core/src/main/java/org/onebusaway/utility/EInRangeStrategy.java
@@ -23,14 +23,15 @@ public enum EInRangeStrategy {
 
   /**
    * As long as two key-values are present in the map, we we will attempt to
-   * interpolate the value for a key that is outside the key range of the
+   * interpolate the value for a key that is inside the key range of the
    * key-value map. If only one key-value pair is present in the map, that value
    * will be used.
    */
   INTERPOLATE,
 
   /**
-   * Takes the closest value in the key-value map.
+   * Returns the value in the key-value map closest to the target value, where the
+   * index for the returned value is less than the index of the target value.
    */
   PREVIOUS_VALUE;
 }

--- a/onebusaway-core/src/main/java/org/onebusaway/utility/EInRangeStrategy.java
+++ b/onebusaway-core/src/main/java/org/onebusaway/utility/EInRangeStrategy.java
@@ -1,0 +1,36 @@
+/**
+ * Copyright (C) 2015 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.utility;
+
+/**
+ * Defines the strategy to use when interpolating a key that is inside the key
+ * range of the key-value map
+ */
+public enum EInRangeStrategy {
+
+  /**
+   * As long as two key-values are present in the map, we we will attempt to
+   * interpolate the value for a key that is outside the key range of the
+   * key-value map. If only one key-value pair is present in the map, that value
+   * will be used.
+   */
+  INTERPOLATE,
+
+  /**
+   * Takes the closest value in the key-value map.
+   */
+  PREVIOUS_VALUE;
+}

--- a/onebusaway-core/src/main/java/org/onebusaway/utility/InterpolationLibrary.java
+++ b/onebusaway-core/src/main/java/org/onebusaway/utility/InterpolationLibrary.java
@@ -24,6 +24,9 @@ import java.util.SortedMap;
  * Generic methods to support interpolation of values against a sorted key-value
  * map given a new target key.
  * 
+ * Note that these interpolation methods do not conform to the GTFS-rt spec.  For GTFS-rt
+ * compliant interpolation/extrapolation, see {@link TransitInterpolationLibrary}.
+ * 
  * @author bdferris
  */
 public class InterpolationLibrary {

--- a/onebusaway-core/src/main/java/org/onebusaway/utility/InterpolationLibrary.java
+++ b/onebusaway-core/src/main/java/org/onebusaway/utility/InterpolationLibrary.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,7 +92,12 @@ public class InterpolationLibrary {
   }
 
   public static double interpolate(double[] keys, double[] values,
-      double target, EOutOfRangeStrategy outOfRangeStrategy) {
+	      double target, EOutOfRangeStrategy outOfRangeStrategy) {
+	  return interpolate(keys, values, target, outOfRangeStrategy, null);
+  }
+
+  public static double interpolate(double[] keys, double[] values,
+      double target, EOutOfRangeStrategy outOfRangeStrategy, EInRangeStrategy inRangeStrategy) {
 
     if (values.length == 0)
       throw new IndexOutOfBoundsException(OUT_OF_RANGE);
@@ -130,8 +136,17 @@ public class InterpolationLibrary {
       }
     }
 
-    return interpolatePair(keys[index - 1], values[index - 1], keys[index],
-        values[index], target);
+    if (inRangeStrategy == null) {
+    	inRangeStrategy = EInRangeStrategy.INTERPOLATE;
+    }
+
+    switch (inRangeStrategy) {
+    case PREVIOUS_VALUE:
+    	return values[index - 1];
+    default:
+    	return interpolatePair(keys[index - 1], values[index - 1], keys[index],
+    			values[index], target);
+    }
   }
 
   /**

--- a/onebusaway-core/src/main/java/org/onebusaway/utility/TransitInterpolationLibrary.java
+++ b/onebusaway-core/src/main/java/org/onebusaway/utility/TransitInterpolationLibrary.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright (C) 2015 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.utility;
+
+import java.util.Arrays;
+
+/**
+ * Transit-specific methods to support searching for deviations (produced from real-time 
+ * predictions) for a given stop.  Interpolation behavior is consistent 
+ * with the GTFS-realtime spec (https://developers.google.com/transit/gtfs-realtime/) when
+ * using the {@link EInRangeStrategy.PREVIOUS_VALUE} and {@link EOutOfRangeStrategy.LAST_VALUE}
+ * strategies - in particular, this applies to the propagation of delays downstream in a trip.
+ * The {@link EInRangeStrategy.INTERPOLATE} and {@link EOutOfRangeStrategy.INTERPOLATE}
+ * strategies have behavior consistent with the normal {@link InterpolationLibrary}, which
+ * do not conform to the GTFS-rt spec.
+ * 
+ */
+public class TransitInterpolationLibrary {
+
+  private static final String OUT_OF_RANGE = "no values provided";
+
+  public static Double interpolate(double[] keys, double[] values,
+      double target, EOutOfRangeStrategy outOfRangeStrategy) {
+    return interpolate(keys, values, target, outOfRangeStrategy, null);
+  }
+
+  /**
+   * Find the deviation that should be used for a particular stop, given sorted keys (arrival times)
+   * and values (deviations) arrays.  The {@code target} is the arrival time for the stop
+   * we're searching for.  Delay propagation is consistent with the GTFS-realtime spec 
+   * (https://developers.google.com/transit/gtfs-realtime/) when using the 
+   * {@link EInRangeStrategy.PREVIOUS_VALUE} and {@link EOutOfRangeStrategy.LAST_VALUE} strategies.  If
+   *  {@link EOutOfRangeStrategy.LAST_VALUE} is provided and all deviations are downstream from the target stop, 
+   * null will be returned to indicate that no real-time information is available for the target stop. 
+   * If {@link EInRangeStrategy.INTERPOLATE} is provided, this method will interpolate using 
+   * linear interpolation and produce a value for a target key within the key-range of the map. 
+   * For a key outside the range of the keys of the map, the {@code outOfRange} {@link EOutOfRangeStrategy}
+   * strategy will determine the interpolation behavior.  {@link EOutOfRangeStrategy.INTERPOLATE}
+   * will linearly extrapolate the value.
+   * 
+   * @param keys sorted array of keys (the scheduled arrival time of the stop)
+   * @param values sorted arrays of values (the list of real-time deviations for the provided stops) 
+   * @param target the target key used to interpolate a value (the scheduled arrival time of the stop)
+   * @param outOfRangeStrategy the strategy to use for a target key that outside
+   *          the key-range of the value map (use {@link EOutOfRangeStrategy.LAST_VALUE} for GTFS-rt behavior)
+   * @param inRangeStrategy the strategy to use for a target key that inside
+   *          the key-range of the value map (use {@link EInRangeStrategy.PREVIOUS_VALUE} for GTFS-rt behavior)
+   * @return an interpolated value (deviation) for the target key, or null if the target is upstream of the deviations
+   */
+  public static Double interpolate(double[] keys, double[] values,
+      double target, EOutOfRangeStrategy outOfRangeStrategy,
+      EInRangeStrategy inRangeStrategy) {
+
+    if (values.length == 0)
+      throw new IndexOutOfBoundsException(OUT_OF_RANGE);
+
+    int index = Arrays.binarySearch(keys, target);
+    if (index >= 0) {
+      // There is a real-time prediction provided for this stop - return it
+      return values[index];
+    }
+
+    // If we get this far, the target value wasn't contained in the keys.  Convert the returned index into the insertion 
+    // index for target, which is the index of the first element greater than the target key (see Arrays.binarySearch()).
+    index = -(index + 1);
+
+    if (index == values.length) {
+      // We're searching for a stop that is downstream of the predictions
+      switch (outOfRangeStrategy) {
+        case INTERPOLATE:
+          if (values.length > 1)
+            return InterpolationLibrary.interpolatePair(keys[index - 2],
+                values[index - 2], keys[index - 1], values[index - 1], target);
+          return values[index - 1];
+        case LAST_VALUE:
+          // Return the closest upstream deviation (i.e., propagate the last deviation in values downstream)
+          return values[index - 1];
+        case EXCEPTION:
+          throw new IndexOutOfBoundsException(OUT_OF_RANGE);
+      }
+    }
+
+    if (index == 0) {
+      // We're searching for a stop that is upstream of the predictions
+      switch (outOfRangeStrategy) {
+        case INTERPOLATE:
+          if (values.length > 1)
+            return InterpolationLibrary.interpolatePair(keys[0], values[0],
+                keys[1], values[1], target);
+          return values[0];
+        case LAST_VALUE:
+          // We shouldn't propagate deviations upstream, so return null to indicate no prediction
+          // should be used, and schedule data should be used instead.
+          return null;
+        case EXCEPTION:
+          throw new IndexOutOfBoundsException(OUT_OF_RANGE);
+      }
+    }
+
+    if (inRangeStrategy == null) {
+      inRangeStrategy = EInRangeStrategy.INTERPOLATE;
+    }
+
+    // We're searching for a stop that is within the window of predictions, but no prediction is provided for
+    // the target stop
+    switch (inRangeStrategy) {
+      case PREVIOUS_VALUE:
+        // Return the closest upstream deviation (i.e., propagate the closest deviation in values downstream)
+        return values[index - 1];
+      default:
+        return InterpolationLibrary.interpolatePair(keys[index - 1],
+            values[index - 1], keys[index], values[index], target);
+    }
+  }
+
+}

--- a/onebusaway-realtime-api/src/main/java/org/onebusaway/realtime/api/TimepointPredictionRecord.java
+++ b/onebusaway-realtime-api/src/main/java/org/onebusaway/realtime/api/TimepointPredictionRecord.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,16 +22,22 @@ import org.onebusaway.gtfs.model.AgencyAndId;
 
 public class TimepointPredictionRecord implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   /**
    * 
    */
   private AgencyAndId timepointId;
+  
+  private AgencyAndId tripId;
+  
+  private int stopSequence = -1;
 
   private long timepointScheduledTime;
 
-  private long timepointPredictedTime;
+  private long timepointPredictedArrivalTime = -1;
+
+  private long timepointPredictedDepartureTime = -1;
 
   public TimepointPredictionRecord() {
 
@@ -38,7 +45,10 @@ public class TimepointPredictionRecord implements Serializable {
 
   public TimepointPredictionRecord(TimepointPredictionRecord r) {
     this.timepointId = r.timepointId;
-    this.timepointPredictedTime = r.timepointPredictedTime;
+    this.tripId = r.tripId;
+    this.stopSequence = r.stopSequence;
+    this.timepointPredictedArrivalTime = r.timepointPredictedArrivalTime;
+    this.timepointPredictedDepartureTime = r.timepointPredictedDepartureTime;
     this.timepointScheduledTime = r.timepointScheduledTime;
   }
 
@@ -58,11 +68,36 @@ public class TimepointPredictionRecord implements Serializable {
     this.timepointScheduledTime = timepointScheduledTime;
   }
 
-  public long getTimepointPredictedTime() {
-    return timepointPredictedTime;
+  public AgencyAndId getTripId() {
+	  return tripId;
   }
 
-  public void setTimepointPredictedTime(long timepointPredictedTime) {
-    this.timepointPredictedTime = timepointPredictedTime;
+  public void setTripId(AgencyAndId tripId) {
+	  this.tripId = tripId;
+  }
+
+  public int getStopSequence() {
+	  return stopSequence;
+  }
+
+  public void setStopSequence(int stopSequence) {
+	  this.stopSequence = stopSequence;
+  }
+
+  public long getTimepointPredictedArrivalTime() {
+	  return timepointPredictedArrivalTime;
+  }
+
+  public void setTimepointPredictedArrivalTime(long timepointPredictedArrivalTime) {
+	  this.timepointPredictedArrivalTime = timepointPredictedArrivalTime;
+  }
+
+  public long getTimepointPredictedDepartureTime() {
+	  return timepointPredictedDepartureTime;
+  }
+
+  public void setTimepointPredictedDepartureTime(
+		  long timepointPredictedDepartureTime) {
+	  this.timepointPredictedDepartureTime = timepointPredictedDepartureTime;
   }
 }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/ArrivalAndDepartureServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/ArrivalAndDepartureServiceImpl.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,8 +58,10 @@ import org.onebusaway.transit_data_federation.services.transit_graph.TripEntry;
 import org.onebusaway.transit_data_federation.services.tripplanner.StopTimeInstance;
 import org.onebusaway.transit_data_federation.services.tripplanner.StopTransfer;
 import org.onebusaway.transit_data_federation.services.tripplanner.StopTransferService;
+import org.onebusaway.utility.EInRangeStrategy;
 import org.onebusaway.utility.EOutOfRangeStrategy;
 import org.onebusaway.utility.InterpolationLibrary;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -656,7 +659,7 @@ class ArrivalAndDepartureServiceImpl implements ArrivalAndDepartureService {
       return (int) InterpolationLibrary.interpolate(
           scheduleDeviations.getScheduleTimes(),
           scheduleDeviations.getScheduleDeviationMus(), arrivalTime,
-          EOutOfRangeStrategy.LAST_VALUE);
+          EOutOfRangeStrategy.LAST_VALUE, EInRangeStrategy.PREVIOUS_VALUE);
     } else if (blockLocation.isScheduleDeviationSet()) {
       return (int) blockLocation.getScheduleDeviation();
     } else {
@@ -874,10 +877,10 @@ class ArrivalAndDepartureServiceImpl implements ArrivalAndDepartureService {
 
     double mu = InterpolationLibrary.interpolate(samples.getScheduleTimes(),
         samples.getScheduleDeviationMus(), stopTime.getArrivalTime(),
-        EOutOfRangeStrategy.LAST_VALUE);
+        EOutOfRangeStrategy.LAST_VALUE, EInRangeStrategy.INTERPOLATE);
     double sigma = InterpolationLibrary.interpolate(samples.getScheduleTimes(),
         samples.getScheduleDeviationSigmas(), stopTime.getArrivalTime(),
-        EOutOfRangeStrategy.LAST_VALUE);
+        EOutOfRangeStrategy.LAST_VALUE, EInRangeStrategy.INTERPOLATE);
 
     long from = (long) (instance.getScheduledArrivalTime() + (mu - sigma) * 1000);
     long to = (long) (instance.getScheduledArrivalTime() + (mu + sigma) * 1000);
@@ -904,10 +907,10 @@ class ArrivalAndDepartureServiceImpl implements ArrivalAndDepartureService {
 
     double mu = InterpolationLibrary.interpolate(samples.getScheduleTimes(),
         samples.getScheduleDeviationMus(), stopTime.getDepartureTime(),
-        EOutOfRangeStrategy.LAST_VALUE);
+        EOutOfRangeStrategy.LAST_VALUE, EInRangeStrategy.INTERPOLATE);
     double sigma = InterpolationLibrary.interpolate(samples.getScheduleTimes(),
         samples.getScheduleDeviationSigmas(), stopTime.getDepartureTime(),
-        EOutOfRangeStrategy.LAST_VALUE);
+        EOutOfRangeStrategy.LAST_VALUE, EInRangeStrategy.INTERPOLATE);
 
     long from = (long) (instance.getScheduledDepartureTime() + (mu - sigma) * 1000);
     long to = (long) (instance.getScheduledDepartureTime() + (mu + sigma) * 1000);

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/TripStatusBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/TripStatusBeanServiceImpl.java
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
  * Copyright (C) 2011 Google, Inc.
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -320,7 +321,10 @@ public class TripStatusBeanServiceImpl implements TripDetailsBeanService {
       for (TimepointPredictionRecord tpr: blockLocation.getTimepointPredictions()) {
         TimepointPredictionBean tpb = new TimepointPredictionBean();
         tpb.setTimepointId(tpr.getTimepointId().toString());
-        tpb.setTimepointPredictedTime(tpr.getTimepointPredictedTime());
+        tpb.setTripId(tpr.getTripId().toString());
+        tpb.setStopSequence(tpr.getStopSequence());
+        tpb.setTimepointPredictedArrivalTime(tpr.getTimepointPredictedArrivalTime());
+        tpb.setTimepointPredictedDepartureTime(tpr.getTimepointPredictedDepartureTime());
         timepointPredictions.add(tpb);
       }
       bean.setTimepointPredictions(timepointPredictions);

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/ScheduledBlockLocationServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/blocks/ScheduledBlockLocationServiceImpl.java
@@ -39,7 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-class ScheduledBlockLocationServiceImpl implements
+public class ScheduledBlockLocationServiceImpl implements
     ScheduledBlockLocationService {
 
   private ShapePointService _shapePointService;

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/BlockLocationRecord.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/BlockLocationRecord.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,7 +101,9 @@ public class BlockLocationRecord {
 
   private final long timepointScheduledTime;
 
-  private final long timepointPredictedTime;
+  private final long timepointPredictedArrivalTime;
+  
+  private final long timepointPredictedDepartureTime;
 
   /**
    * Custom Hibernate mapping so that the vehicle phase enum gets mapped to a
@@ -137,7 +140,8 @@ public class BlockLocationRecord {
     orientation = null;
     timepointId = null;
     timepointScheduledTime = 0;
-    timepointPredictedTime = 0;
+    timepointPredictedArrivalTime = -1;
+    timepointPredictedDepartureTime = -1;
     phase = null;
     status = null;
     vehicleId = null;
@@ -156,7 +160,8 @@ public class BlockLocationRecord {
     this.orientation = builder.orientation;
     this.timepointId = builder.timepointId;
     this.timepointScheduledTime = builder.timepointScheduledTime;
-    this.timepointPredictedTime = builder.timepointPredictedTime;
+    this.timepointPredictedArrivalTime = builder.timepointPredictedArrivalTime;
+    this.timepointPredictedDepartureTime = builder.timepointPredictedDepartureTime;
     this.phase = builder.phase;
     this.status = builder.status;
     this.vehicleId = builder.vehicleId;
@@ -261,8 +266,12 @@ public class BlockLocationRecord {
     return timepointScheduledTime;
   }
 
-  public long getTimepointPredictedTime() {
-    return timepointPredictedTime;
+  public long getTimepointPredictedArrivalTime() {
+    return timepointPredictedArrivalTime;
+  }
+
+  public long getTimepointPredictedDepartureTime() {
+    return timepointPredictedDepartureTime;
   }
 
   public EVehiclePhase getPhase() {
@@ -316,7 +325,9 @@ public class BlockLocationRecord {
 
     private long timepointScheduledTime;
 
-    private long timepointPredictedTime;
+    private long timepointPredictedArrivalTime;
+
+    private long timepointPredictedDepartureTime;
 
     private EVehiclePhase phase;
 
@@ -382,8 +393,12 @@ public class BlockLocationRecord {
       this.timepointScheduledTime = timepointScheduledTime;
     }
 
-    public void setTimepointPredictedTime(long timepointPredictedTime) {
-      this.timepointPredictedTime = timepointPredictedTime;
+    public void setTimepointPredictedArrivalTime(long timepointPredictedArrivalTime) {
+      this.timepointPredictedArrivalTime = timepointPredictedArrivalTime;
+    }
+
+    public void setTimepointPredictedDepartureTime(long timepointPredictedDepartureTime) {
+      this.timepointPredictedDepartureTime = timepointPredictedDepartureTime;
     }
 
     public void setPhase(EVehiclePhase phase) {

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/VehicleLocationRecordCacheImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/VehicleLocationRecordCacheImpl.java
@@ -52,7 +52,7 @@ import org.springframework.stereotype.Component;
  * @param record record to add
  */
 @Component
-class VehicleLocationRecordCacheImpl implements VehicleLocationRecordCache {
+public class VehicleLocationRecordCacheImpl implements VehicleLocationRecordCache {
 
   private static Logger _log = LoggerFactory.getLogger(VehicleLocationRecordCacheImpl.class);
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeServiceImpl.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2011 Google, Inc.
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,9 +117,17 @@ class GtfsRealtimeServiceImpl implements GtfsRealtimeService {
            stopTimeUpdate.setStopId(AgencyAndId.convertToString(tpr.getTimepointId()));
            stopTimeUpdate.setScheduleRelationship(com.google.transit.realtime.GtfsRealtime.TripUpdate.StopTimeUpdate.ScheduleRelationship.SCHEDULED);
       
-           StopTimeEvent.Builder stopTimeEvent = StopTimeEvent.newBuilder();
-           stopTimeEvent.setTime(tpr.getTimepointPredictedTime());
-           stopTimeUpdate.setArrival(stopTimeEvent);
+           if (tpr.getTimepointPredictedArrivalTime() != -1) {
+             StopTimeEvent.Builder arrivalStopTimeEvent = StopTimeEvent.newBuilder();
+             arrivalStopTimeEvent.setTime(tpr.getTimepointPredictedArrivalTime());
+             stopTimeUpdate.setArrival(arrivalStopTimeEvent);
+           }
+   
+           if (tpr.getTimepointPredictedDepartureTime() != -1) {
+             StopTimeEvent.Builder departureStopTimeEvent = StopTimeEvent.newBuilder();
+             departureStopTimeEvent.setTime(tpr.getTimepointPredictedDepartureTime());
+             stopTimeUpdate.setDeparture(departureStopTimeEvent);
+           }
    
            tripUpdate.addStopTimeUpdate(stopTimeUpdate); 
         }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
@@ -1,6 +1,7 @@
 /**
  * Copyright (C) 2013 Kurt Raschke <kurt@kurtraschke.com>
  * Copyright (C) 2011 Google, Inc.
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -363,24 +364,40 @@ class GtfsRealtimeTripLibrary {
                 instance.getServiceDate());
             if (blockStopTime == null)
               continue;
+
             StopTimeEntry stopTime = blockStopTime.getStopTime();
+
+            TimepointPredictionRecord tpr = new TimepointPredictionRecord();
+            tpr.setTimepointId(stopTime.getStop().getId());
+            tpr.setTripId(stopTime.getTrip().getId());
+            if (stopTimeUpdate.hasStopSequence()) {
+              tpr.setStopSequence(stopTimeUpdate.getStopSequence());
+            }
+
             int currentArrivalTime = computeArrivalTime(stopTime,
                 stopTimeUpdate, instance.getServiceDate());
+            int currentDepartureTime = computeDepartureTime(stopTime,
+                stopTimeUpdate, instance.getServiceDate());
+
             if (currentArrivalTime >= 0) {
               updateBestScheduleDeviation(currentTime,
                   stopTime.getArrivalTime(), currentArrivalTime, best);
-              
+
               long timepointPredictedTime = instance.getServiceDate() + (currentArrivalTime * 1000L);
-              TimepointPredictionRecord tpr = new TimepointPredictionRecord();
-              tpr.setTimepointId(stopTime.getStop().getId());
-              tpr.setTimepointPredictedTime(timepointPredictedTime);
-              timepointPredictions.add(tpr);
-            }
-            int currentDepartureTime = computeDepartureTime(stopTime,
-                stopTimeUpdate, instance.getServiceDate());
+              tpr.setTimepointPredictedArrivalTime(timepointPredictedTime);
+            } 
+
             if (currentDepartureTime >= 0) {
               updateBestScheduleDeviation(currentTime,
                   stopTime.getDepartureTime(), currentDepartureTime, best);
+
+              long timepointPredictedTime = instance.getServiceDate() + (currentDepartureTime * 1000L);
+              tpr.setTimepointPredictedDepartureTime(timepointPredictedTime);
+            }
+
+            if (tpr.getTimepointPredictedArrivalTime() != -1 || 
+                tpr.getTimepointPredictedDepartureTime() != -1) {
+              timepointPredictions.add(tpr);
             }
           }
         }

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/mybus/TimepointPredictionServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/mybus/TimepointPredictionServiceImpl.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2011 Brian Ferris <bdferris@onebusaway.org>
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -303,7 +304,7 @@ public class TimepointPredictionServiceImpl {
     if (_includeTimepointPredictionRecords) {
       TimepointPredictionRecord tpr = new TimepointPredictionRecord();
       tpr.setTimepointId(best.getTimepointId());
-      tpr.setTimepointPredictedTime(best.getTimepointPredictedTime());
+      tpr.setTimepointPredictedArrivalTime(best.getTimepointPredictedTime());
       tpr.setTimepointScheduledTime(best.getTimepointScheduledTime());
       r.setTimepointPredictions(Arrays.asList(tpr));
     }

--- a/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/impl/ArrivalAndDepartureServiceImplTest.java
+++ b/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/impl/ArrivalAndDepartureServiceImplTest.java
@@ -1,0 +1,760 @@
+/**
+ * Copyright (C) 2015 University of South Florida
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.transit_data_federation.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.block;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.blockConfiguration;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.dateAsLong;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.lsids;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.serviceIds;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.stop;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.stopTime;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.time;
+import static org.onebusaway.transit_data_federation.testing.UnitTestingSupport.trip;
+
+import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.realtime.api.TimepointPredictionRecord;
+import org.onebusaway.realtime.api.VehicleLocationRecord;
+import org.onebusaway.transit_data_federation.impl.blocks.BlockStatusServiceImpl;
+import org.onebusaway.transit_data_federation.impl.blocks.ScheduledBlockLocationServiceImpl;
+import org.onebusaway.transit_data_federation.impl.realtime.BlockLocationServiceImpl;
+import org.onebusaway.transit_data_federation.impl.realtime.VehicleLocationRecordCacheImpl;
+import org.onebusaway.transit_data_federation.impl.transit_graph.BlockEntryImpl;
+import org.onebusaway.transit_data_federation.impl.transit_graph.StopEntryImpl;
+import org.onebusaway.transit_data_federation.impl.transit_graph.TripEntryImpl;
+import org.onebusaway.transit_data_federation.model.TargetTime;
+import org.onebusaway.transit_data_federation.services.StopTimeService;
+import org.onebusaway.transit_data_federation.services.StopTimeService.EFrequencyStopTimeBehavior;
+import org.onebusaway.transit_data_federation.services.blocks.BlockInstance;
+import org.onebusaway.transit_data_federation.services.blocks.BlockStatusService;
+import org.onebusaway.transit_data_federation.services.blocks.ScheduledBlockLocation;
+import org.onebusaway.transit_data_federation.services.realtime.ArrivalAndDepartureInstance;
+import org.onebusaway.transit_data_federation.services.realtime.BlockLocation;
+import org.onebusaway.transit_data_federation.services.transit_graph.BlockConfigurationEntry;
+import org.onebusaway.transit_data_federation.services.transit_graph.BlockStopTimeEntry;
+import org.onebusaway.transit_data_federation.services.transit_graph.StopTimeEntry;
+import org.onebusaway.transit_data_federation.services.tripplanner.StopTimeInstance;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Tests to see if the per stop time point predictions provided by a real-time
+ * feed are correctly applied to the scheduled time, so the correct predicted
+ * arrival times are produced. Behavior for propagating times is consistent with
+ * the GTFS-realtime spec
+ * (https://developers.google.com/transit/gtfs-realtime/).
+ * 
+ * @author cetin
+ * @author barbeau
+ */
+public class ArrivalAndDepartureServiceImplTest {
+
+  private ArrivalAndDepartureServiceImpl _service;
+
+  private BlockStatusService _blockStatusService;
+
+  private StopTimeService _stopTimeService;
+
+  private BlockLocationServiceImpl _blockLocationService;
+
+  // Setup current time
+  private long mCurrentTime = dateAsLong("2015-07-23 13:00");
+
+  private long mServiceDate = dateAsLong("2015-07-23 00:00");
+
+  // Stops
+  private StopEntryImpl mStopA = stop("stopA", 47.0, -122.0);
+
+  private StopEntryImpl mStopB = stop("stopB", 47.0, -128.0);
+
+  private TripEntryImpl mTripA = trip("tripA", "sA", 3000);
+
+  @Before
+  public void setup() {
+    _service = new ArrivalAndDepartureServiceImpl();
+
+    _blockStatusService = new BlockStatusServiceImpl();
+    _service.setBlockStatusService(_blockStatusService);
+
+    _stopTimeService = Mockito.mock(StopTimeServiceImpl.class);
+    _service.setStopTimeService(_stopTimeService);
+
+    _blockLocationService = new BlockLocationServiceImpl();
+    _blockLocationService.setLocationInterpolation(false);
+    _service.setBlockLocationService(_blockLocationService);
+  }
+
+  /**
+   * This method tests time point predictions upstream of a stop for *arrival*
+   * times.
+   * 
+   * Test configuration: Time point predictions are upstream of the stop and
+   * include the given stop_ids, which means that the bus hasn't passed these
+   * bus stops yet. There are 2 bus stops which have the real time arrival times
+   * (time point predictions). In this case
+   * getArrivalsAndDeparturesForStopInTimeRange() should return the absolute
+   * time point prediction for particular stop that was provided by the feed,
+   * which replaces the scheduled time from GTFS for these stops.
+   * 
+   * Current time = 13:00 
+   *        Schedule time    Real-time from feed 
+   * Stop A 13:30            13:30
+   * Stop B 13:40            13:50
+   * 
+   * When requesting arrival estimate for Stop B, result should be 13:50 (same
+   * as exact prediction from real-time feed).
+   */
+  @Test
+  public void testGetArrivalsAndDeparturesForStopInTimeRange01() {
+
+    // Set time point predictions for stop A
+    TimepointPredictionRecord tprA = new TimepointPredictionRecord();
+    tprA.setTimepointId(mStopA.getId());
+    long tprATime = createPredictedTime(time(13, 30));
+    tprA.setTimepointPredictedArrivalTime(tprATime);
+    tprA.setTripId(mTripA.getId());
+
+    // Set time point predictions for stop B
+    TimepointPredictionRecord tprB = new TimepointPredictionRecord();
+    tprB.setTimepointId(mStopB.getId());
+    long tprBTime = createPredictedTime(time(13, 50));
+    tprB.setTimepointPredictedArrivalTime(tprBTime);
+    tprB.setTripId(mTripA.getId());
+
+    // Call ArrivalsAndDeparturesForStopInTimeRange method in
+    // ArrivalAndDepartureServiceImpl
+    List<ArrivalAndDepartureInstance> arrivalsAndDepartures = getArrivalsAndDeparturesForStopInTimeRangeByTimepointPredictionRecord(Arrays.asList(
+        tprA, tprB));
+
+    long predictedArrivalTime = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+    /**
+     * Check if the predictedArrivalTime is exactly the same as the
+     * TimepointPrediction.
+     */
+    assertEquals(tprB.getTimepointPredictedArrivalTime(), predictedArrivalTime);
+  }
+
+  /**
+   * This method tests upstream time point predictions for scheduled *arrival*
+   * times.
+   * 
+   * Test configuration: Time point predictions are upstream of the current
+   * stop_id, which means that the bus hasn't passed the bus stop yet. A real
+   * time arrival time (time point prediction) is provided for only one bus stop
+   * (Stop A). In this case getArrivalsAndDeparturesForStopInTimeRange() should
+   * calculate a new arrival time for Stop B (based on the upstream prediction
+   * for Stop A), which is the scheduled arrival time + the upstream deviation.
+   * 
+   * Current time = 13:00 
+   *          Schedule time    Real-time from feed
+   * Stop A   13:30            13:35
+   * Stop B   13:40            ---
+   * 
+   * We are requesting arrival time for Stop B, which should be propagated
+   * downstream from Stop A's prediction, which should be 13:45 (13:40 + 5 min
+   * deviation from Stop A). Stop A's predicted arrival and departure should
+   * also be the respective scheduled arrival and departure plus the 5 min
+   * deviation.
+   * 
+   */
+  @Test
+  public void testGetArrivalsAndDeparturesForStopInTimeRange02() {
+
+    // Set time point predictions for stop A
+    TimepointPredictionRecord tprA = new TimepointPredictionRecord();
+    tprA.setTimepointId(mStopA.getId());
+    long tprATime = createPredictedTime(time(13, 35));
+    tprA.setTimepointPredictedArrivalTime(tprATime);
+    tprA.setTripId(mTripA.getId());
+
+    // Call ArrivalsAndDeparturesForStopInTimeRange method in
+    // ArrivalAndDepartureServiceImpl
+    List<ArrivalAndDepartureInstance> arrivalsAndDepartures = getArrivalsAndDeparturesForStopInTimeRangeByTimepointPredictionRecord(Arrays.asList(tprA));
+
+    long predictedArrivalTimeStopA = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopA.getId());
+    long predictedDepartureTimeStopA = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopA.getId());
+    long predictedArrivalTimeStopB = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+    long predictedDepartureTimeStopB = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+
+    long scheduledArrivalTimeStopA = getScheduledArrivalTimeByStopId(mTripA,
+        mStopA.getId());
+    long scheduledDepartureTimeStopA = getScheduledDepartureTimeByStopId(
+        mTripA, mStopA.getId());
+    long scheduledArrivalTimeStopB = getScheduledArrivalTimeByStopId(mTripA,
+        mStopB.getId());
+    long scheduledDepartureTimeStopB = getScheduledDepartureTimeByStopId(
+        mTripA, mStopB.getId());
+
+    // The time point prediction for Stop A was 5 min late, so this should be
+    // applied to Stop B scheduled arrival
+    long delta = TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopA)
+        - scheduledArrivalTimeStopA;
+    assertEquals(TimeUnit.MINUTES.toSeconds(5), delta);
+
+    // Check if the predictedArrivalTimes and predictedDepartureTimes is the
+    // same as the scheduledArrivalTime plus the delta
+    assertEquals(TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopA),
+        scheduledArrivalTimeStopA + delta);
+    assertEquals(TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopA),
+        scheduledDepartureTimeStopA + delta);
+    assertEquals(TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopB),
+        scheduledArrivalTimeStopB + delta);
+    assertEquals(TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopB),
+        scheduledDepartureTimeStopB + delta);
+  }
+
+  /**
+   * This method tests upstream time point predictions with only a predicted
+   * *departure* time.
+   * 
+   * Test configuration: There is only one bus stop (Stop A) which has the real
+   * time departure time (time point prediction). In this case
+   * getArrivalsAndDeparturesForStopInTimeRange() should return the time point
+   * prediction for Stop A's departure time, which replaces the scheduled time
+   * from GTFS for this stop. For Stop B, the upstream departure prediction for
+   * Stop A should be propagated down to Stop B, and this deviation should be
+   * used to calculate Stop B's arrival and departure times.
+   * 
+   * Current time = 13:00 
+   *          Schedule Arrival time    Schedule Departure time    Real-time departure time
+   * Stop A   13:30                    13:35                      13:30
+   * Stop B   13:45                    13:50                      ----
+   * 
+   * When requesting arrival estimate for Stop A, result should be 0 (note this
+   * isn't currently supported - see TODO in method body).
+   * 
+   * When requesting departure estimate for Stop A, result should be exactly
+   * same with the real-time feed's departure time for Stop A.
+   * 
+   * When requesting arrival and departure estimate for Stop B, the result
+   * should be 5 min less then the scheduled arrival and departure times.
+   * Because the upstream stop departs 5 min early, OBA should subtract this 5
+   * min deviation from the downstream scheduled values.
+   */
+  @Test
+  public void testGetArrivalsAndDeparturesForStopInTimeRange03() {
+
+    // Set time point predictions for stop A
+    TimepointPredictionRecord tprA = new TimepointPredictionRecord();
+    tprA.setTimepointId(mStopA.getId());
+    long tprATime = createPredictedTime(time(13, 30));
+    tprA.setTimepointPredictedDepartureTime(tprATime);
+    tprA.setTripId(mTripA.getId());
+
+    // Call ArrivalsAndDeparturesForStopInTimeRange method in
+    // ArrivalAndDepartureServiceImpl
+    List<ArrivalAndDepartureInstance> arrivalsAndDepartures = getArrivalsAndDeparturesForStopInTimeRangeByTimepointPredictionRecord(Arrays.asList(tprA));
+
+    long predictedArrivalTimeStopA = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopA.getId());
+
+    long predictedDepartureTimeStopA = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopA.getId());
+    /**
+     * Check if the predictedDepartureTime is exactly the same with
+     * TimepointPrediction.
+     */
+    assertEquals(tprA.getTimepointPredictedDepartureTime(),
+        predictedDepartureTimeStopA);
+
+    /**
+     * TODO - Fully support both real-time arrival and departure times for each
+     * stop in OBA
+     * 
+     * We're currently limited by OBA's internal data model which contains only
+     * one deviation per stop. By GTFS-rt spec, if no real-time arrival
+     * information is given for a stop, then the scheduled arrival should be
+     * used. In our case here, we're getting a real-time departure for Stop A
+     * (and no real-time arrival time for Stop A), but then we're showing the
+     * real-time departure info for Stop A as the real-time arrival time for
+     * Stop A. So, we're effectively propagating the real-time value backwards
+     * within the same stop. The correct value for predictedArrivalTimeStopA is
+     * actually 0, because we don't have any real-time arrival information for
+     * Stop A (or upstream of Stop A).
+     * 
+     * So, the below assertion is currently commented out, as it fails. Future
+     * work should overhaul OBA's data model to support more than one real-time
+     * deviation per stop. When this is correctly implemented, the below
+     * assertion should be uncommented and it should pass.
+     */
+    // assertEquals(0, predictedArrivalTimeStopA);
+
+    /**
+     * Test for Stop B
+     */
+
+    long predictedArrivalTimeStopB = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+
+    long predictedDepartureTimeStopB = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+
+    long scheduledDepartureTimeForStopA = getScheduledDepartureTimeByStopId(
+        mTripA, mStopA.getId());
+    long scheduledArrivalTimeForStopB = getScheduledArrivalTimeByStopId(mTripA,
+        mStopB.getId());
+    long scheduledDepartureTimeForStopB = getScheduledDepartureTimeByStopId(
+        mTripA, mStopB.getId());
+
+    // Calculate the departure time difference from the upstream stop
+    long deltaB = (scheduledDepartureTimeForStopA - TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopA));
+
+    /**
+     * Check if the predictedArrivalTime is 5 min less then the scheduled
+     * arrival time for stop B.
+     */
+    assertEquals(TimeUnit.MINUTES.toSeconds(5), deltaB);
+    assertEquals(scheduledArrivalTimeForStopB - deltaB,
+        TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopB));
+
+    /**
+     * Check if the predictedDepartureTime is 5 min less then the scheduled
+     * departure time for stop B.
+     */
+    assertEquals(scheduledDepartureTimeForStopB - deltaB,
+        TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopB));
+  }
+
+  /**
+   * This method tests upstream time point predictions with both predicted
+   * arrival and departure times.
+   * 
+   * Test configuration: Time point predictions are upstream and include the
+   * current stop_id, which means that the bus hasn't passed the bus stop yet.
+   * There is only one bus stop (Stop A) which has the real time arrival and
+   * departure times (time point prediction). In this case
+   * getArrivalsAndDeparturesForStopInTimeRange() should return absolute time
+   * point prediction for Stop A's departure time, which replaces the scheduled
+   * time from GTFS for this stop. Stop B's predictions should be derived from
+   * the upstream predictions provided for Stop A.
+   * 
+   * Current time = 13:00 
+   *          Schedule Arrival time    Schedule Departure time    Real-time arrival time    Real-time departure time
+   * Stop A   13:30                    13:35                      13:20                     13:30
+   * Stop B   13:45                    13:50                      -----                     -----
+   * 
+   * When requesting arrival estimate for Stop A, result should be 13:20
+   * (predicted real-time arrival time). Note that this currently isn't support
+   * - see TODO statement in method body.
+   * 
+   * When requesting departure estimate for Stop A, result should be 13:30
+   * (predicted real-time departure time).
+   * 
+   * When requesting arrival and departure estimates for Stop B, results should
+   * be 5 min less then the scheduled arrival and departure times. Because the
+   * upstream Stop A departs 5 min early, OBA should subtract this 5 min from
+   * the downstream estimates.
+   */
+  @Test
+  public void testGetArrivalsAndDeparturesForStopInTimeRange04() {
+
+    // Set time point predictions for stop A
+    TimepointPredictionRecord tprA = new TimepointPredictionRecord();
+    tprA.setTimepointId(mStopA.getId());
+    long tprADepartureTime = createPredictedTime(time(13, 30));
+    tprA.setTimepointPredictedDepartureTime(tprADepartureTime);
+    long tprAArrivalTime = createPredictedTime(time(13, 20));
+    tprA.setTimepointPredictedArrivalTime(tprAArrivalTime);
+    tprA.setTripId(mTripA.getId());
+
+    // Call ArrivalsAndDeparturesForStopInTimeRange method in
+    // ArrivalAndDepartureServiceImpl
+    List<ArrivalAndDepartureInstance> arrivalsAndDepartures = getArrivalsAndDeparturesForStopInTimeRangeByTimepointPredictionRecord(Arrays.asList(tprA));
+
+    long predictedDepartureTimeStopA = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopA.getId());
+    /**
+     * Check if the predictedDepartureTime is exactly the same with
+     * TimepointPrediction.
+     */
+    assertEquals(tprA.getTimepointPredictedDepartureTime(),
+        predictedDepartureTimeStopA);
+
+    /**
+     * TODO - Fully support both real-time arrival and departure times for each
+     * stop in OBA
+     * 
+     * We're currently limited by OBA's internal data model which contains only
+     * one deviation per stop. By GTFS-rt spec, if real-time arrival information
+     * is given for a stop, then it should be used. In our case we expect to get
+     * 13:20 as predictedArrivalTime, as this is the predicted arrival time
+     * supplied in the real-time feed. However, we are getting 13:25 as
+     * predictedArrivalTime, which is actually the predictedDepartureTime for
+     * this stop. This is because OBA must prefer predicted departure times to
+     * arrival times when only one deviation per stop is supported, as the
+     * departure times are what should be propagated downstream.
+     * 
+     * So, the below assertion is currently commented out, as it fails. Future
+     * work should overhaul OBA's data model to support more than one real-time
+     * deviation per stop. When this is correctly implemented, the below
+     * assertion should be uncommented and it should pass.
+     */
+
+    // long predictedArrivalTimeStopA = getPredictedArrivalTimeByStopId(
+    // arrivalsAndDepartures, stopA.getId());
+    //
+    // assertEquals(TimeUnit.MILLISECONDS.toSeconds(tprA.getTimepointPredictedArrivalTime()),
+    // TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopA));
+
+    /**
+     * Test for Stop B
+     */
+
+    long scheduledDepartureTimeForStopA = getScheduledDepartureTimeByStopId(
+        mTripA, mStopA.getId());
+
+    long predictedArrivalTimeStopB = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+
+    long predictedDepartureTimeStopB = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+
+    long scheduledArrivalTimeForStopB = getScheduledArrivalTimeByStopId(mTripA,
+        mStopB.getId());
+    long scheduledDepartureTimeForStopB = getScheduledDepartureTimeByStopId(
+        mTripA, mStopB.getId());
+
+    // Calculate the departure time difference from the upstream stop
+    long deltaB = scheduledDepartureTimeForStopA
+        - TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopA);
+
+    /**
+     * Check if the predictedDepartureTime is 5 min less then the scheduled
+     * departure time for stop B.
+     */
+    assertEquals(TimeUnit.MINUTES.toSeconds(5), deltaB);
+    assertEquals(scheduledDepartureTimeForStopB - deltaB,
+        TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopB));
+
+    /**
+     * Check if the predictedArrivalTime is 5 min less then the scheduled
+     * arrival time for stop B.
+     */
+    assertEquals(scheduledArrivalTimeForStopB - deltaB,
+        TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopB));
+  }
+
+  /**
+   * This method tests a request for an arrival time for a stop, when the
+   * current time is greater than the arrival time prediction for that stop
+   * (Stop B). In other words, the bus is predicted to have already passed the
+   * stop (Stop B).
+   * 
+   * Test configuration: There are 2 bus stops which have the real time arrival
+   * times (time point predictions) - Stop A and B. In this case
+   * getArrivalsAndDeparturesForStopInTimeRange() should return last received
+   * time point prediction for particular stop we're requesting information for.
+   * 
+   * Current time = 14:00 
+   *          Schedule time    Real-time from feed
+   * Stop A   13:30            13:30
+   * Stop B   13:40            13:50
+   * 
+   */
+  @Test
+  public void testGetArrivalsAndDeparturesForStopInTimeRange05() {
+    // Override the current time with a later time than the time point
+    // predictions
+    mCurrentTime = dateAsLong("2015-07-23 14:00");
+
+    // Set time point predictions for stop A
+    TimepointPredictionRecord tprA = new TimepointPredictionRecord();
+    tprA.setTimepointId(mStopA.getId());
+    long tprATime = createPredictedTime(time(13, 30));
+    tprA.setTimepointPredictedArrivalTime(tprATime);
+    tprA.setTripId(mTripA.getId());
+
+    // Set time point predictions for stop B
+    TimepointPredictionRecord tprB = new TimepointPredictionRecord();
+    tprB.setTimepointId(mStopB.getId());
+    long tprBTime = createPredictedTime(time(13, 50));
+    tprB.setTimepointPredictedArrivalTime(tprBTime);
+    tprB.setTripId(mTripA.getId());
+
+    // Call ArrivalsAndDeparturesForStopInTimeRange method in
+    // ArrivalAndDepartureServiceImpl
+    List<ArrivalAndDepartureInstance> arrivalsAndDepartures = getArrivalsAndDeparturesForStopInTimeRangeByTimepointPredictionRecord(Arrays.asList(
+        tprA, tprB));
+
+    long predictedArrivalTimeStopA = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopA.getId());
+    long predictedArrivalTimeStopB = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+
+    /**
+     * Check if the predictedArrivalTime is exactly the same as
+     * TimepointPrediction for both stops
+     */
+    assertEquals(tprA.getTimepointPredictedArrivalTime(),
+        predictedArrivalTimeStopA);
+    assertEquals(tprB.getTimepointPredictedArrivalTime(),
+        predictedArrivalTimeStopB);
+
+    /**
+     * Check if the predictedDepartureTimes and scheduledDepartureTimes have the
+     * same delta as arrival predictions and scheduled arrival times for both
+     * stops
+     */
+    long predictedDepartureTimeStopA = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopA.getId());
+    long predictedDepartureTimeStopB = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+
+    long scheduledArrivalTimeForStopA = getScheduledArrivalTimeByStopId(mTripA,
+        mStopA.getId());
+    long scheduledArrivalTimeForStopB = getScheduledArrivalTimeByStopId(mTripA,
+        mStopB.getId());
+    long scheduledDepartureTimeForStopA = getScheduledDepartureTimeByStopId(
+        mTripA, mStopA.getId());
+    long scheduledDepartureTimeForStopB = getScheduledDepartureTimeByStopId(
+        mTripA, mStopB.getId());
+
+    long deltaA = TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopA)
+        - scheduledArrivalTimeForStopA;
+    assertEquals(scheduledDepartureTimeForStopA + deltaA,
+        TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopA));
+
+    long deltaB = TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopB)
+        - scheduledArrivalTimeForStopB;
+    assertEquals(scheduledDepartureTimeForStopB + deltaB,
+        TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopB));
+  }
+
+  /**
+   * This method tests to make sure upstream propagation isn't happening.
+   * 
+   * Test configuration: Time point predictions are downstream of Stop A, which
+   * means that the bus is predicted to have already passed the bus stop. There
+   * only one bus stop (Stop B) which has a real time arrival time (time point
+   * prediction). In this case getArrivalsAndDeparturesForStopInTimeRange() for
+   * Stop A should return a predicted arrival time = 0, indicating that no
+   * real-time information is available for Stop A.
+   * 
+   * Current time = 14:00
+   *          Schedule time    Real-time from feed
+   * Stop A   13:30            -----
+   * Stop B   13:45            13:40
+   * 
+   * Since the bus already passed the bus stop A, and no real-time information
+   * is available for Stop A, OBA should NOT propagate arrival estimate for Stop
+   * B upstream to Stop A.
+   */
+  @Test
+  public void testGetArrivalsAndDeparturesForStopInTimeRange06() {
+    // Override the current time with a later time than the time point
+    // predictions
+    mCurrentTime = dateAsLong("2015-07-23 14:00");
+
+    // Set time point predictions for stop B
+    TimepointPredictionRecord tprB = new TimepointPredictionRecord();
+    tprB.setTimepointId(mStopB.getId());
+    long tprBTime = createPredictedTime(time(13, 40));
+    tprB.setTimepointPredictedArrivalTime(tprBTime);
+    tprB.setTripId(mTripA.getId());
+
+    // Call ArrivalsAndDeparturesForStopInTimeRange method in
+    // ArrivalAndDepartureServiceImpl
+    List<ArrivalAndDepartureInstance> arrivalsAndDepartures = getArrivalsAndDeparturesForStopInTimeRangeByTimepointPredictionRecord(Arrays.asList(tprB));
+
+    long predictedArrivalTimeStopB = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+    /**
+     * Check if the predictedArrivalTime for stop B is exactly the same as
+     * TimepointPredictionRecord.
+     */
+    assertEquals(tprB.getTimepointPredictedArrivalTime(),
+        predictedArrivalTimeStopB);
+
+    /**
+     * Check predicted departure for Stop B too, to make sure its propagated
+     * from provided predicted arrival time
+     */
+    long scheduledArrivalTimeForStopB = getScheduledArrivalTimeByStopId(mTripA,
+        mStopB.getId());
+    long scheduledDepartureTimeForStopB = getScheduledDepartureTimeByStopId(
+        mTripA, mStopB.getId());
+    long predictedDepartureTimeStopB = getPredictedDepartureTimeByStopId(
+        arrivalsAndDepartures, mStopB.getId());
+    long deltaB = TimeUnit.MILLISECONDS.toSeconds(predictedArrivalTimeStopB)
+        - scheduledArrivalTimeForStopB;
+    assertEquals(scheduledDepartureTimeForStopB + deltaB,
+        TimeUnit.MILLISECONDS.toSeconds(predictedDepartureTimeStopB));
+
+    /**
+     * Make sure the predictedArrivalTime for stop A is equals to 0 - in other
+     * words, we should show no real-time information for this stop and use the
+     * scheduled time instead.
+     */
+
+    long predictedArrivalTimeA = getPredictedArrivalTimeByStopId(
+        arrivalsAndDepartures, mStopA.getId());
+    assertEquals(0, predictedArrivalTimeA);
+  }
+
+  /**
+   * Set up the BlockLocationServiceImpl for the test, using the given
+   * timepointPredictions
+   * 
+   * @param timepointPredictions real-time predictions to apply to the
+   *          BlockLocationServiceImpl
+   * @return a list of ArrivalAndDepartureInstances which is used to access
+   *         predicted arrival/departure times for a stop, for comparison
+   *         against the expected values
+   */
+  private List<ArrivalAndDepartureInstance> getArrivalsAndDeparturesForStopInTimeRangeByTimepointPredictionRecord(
+      List<TimepointPredictionRecord> timepointPredictions) {
+    TargetTime target = new TargetTime(mCurrentTime, mCurrentTime);
+
+    // Setup block
+    BlockEntryImpl block = block("blockA");
+
+    stopTime(0, mStopA, mTripA, time(13, 30), time(13, 35), 1000);
+    stopTime(1, mStopB, mTripA, time(13, 45), time(13, 50), 2000);
+
+    BlockConfigurationEntry blockConfig = blockConfiguration(block,
+        serviceIds(lsids("sA"), lsids()), mTripA);
+    BlockStopTimeEntry bstAA = blockConfig.getStopTimes().get(0);
+    BlockStopTimeEntry bstAB = blockConfig.getStopTimes().get(1);
+    BlockStopTimeEntry bstBA = blockConfig.getStopTimes().get(0);
+
+    // Setup block location instance for trip B
+    BlockInstance blockInstance = new BlockInstance(blockConfig, mServiceDate);
+    BlockLocation blockLocationB = new BlockLocation();
+    blockLocationB.setActiveTrip(bstBA.getTrip());
+    blockLocationB.setBlockInstance(blockInstance);
+    blockLocationB.setClosestStop(bstBA);
+    blockLocationB.setDistanceAlongBlock(400);
+    blockLocationB.setInService(true);
+    blockLocationB.setNextStop(bstAA);
+    blockLocationB.setPredicted(false);
+    blockLocationB.setScheduledDistanceAlongBlock(400);
+
+    blockLocationB.setTimepointPredictions(timepointPredictions);
+
+    // Mock StopTimeInstance with time frame
+    long stopTimeFrom = dateAsLong("2015-07-23 00:00");
+    long stopTimeTo = dateAsLong("2015-07-24 00:00");
+
+    StopTimeInstance sti1 = new StopTimeInstance(bstAB,
+        blockInstance.getState());
+    ArrivalAndDepartureInstance in1 = new ArrivalAndDepartureInstance(sti1);
+    in1.setBlockLocation(blockLocationB);
+    in1.setPredictedArrivalTime((long) (in1.getScheduledArrivalTime()));
+    in1.setPredictedDepartureTime((long) (in1.getScheduledDepartureTime()));
+
+    StopTimeInstance sti2 = new StopTimeInstance(bstBA,
+        blockInstance.getState());
+    ArrivalAndDepartureInstance in2 = new ArrivalAndDepartureInstance(sti2);
+    in2.setBlockLocation(blockLocationB);
+
+    Date fromTimeBuffered = new Date(stopTimeFrom
+        - _blockStatusService.getRunningLateWindow() * 1000);
+    Date toTimeBuffered = new Date(stopTimeTo
+        + _blockStatusService.getRunningEarlyWindow() * 1000);
+
+    Mockito.when(
+        _stopTimeService.getStopTimeInstancesInTimeRange(mStopB,
+            fromTimeBuffered, toTimeBuffered,
+            EFrequencyStopTimeBehavior.INCLUDE_UNSPECIFIED)).thenReturn(
+        Arrays.asList(sti1, sti2));
+
+    // Create and add vehicle location record cache
+    VehicleLocationRecordCacheImpl _cache = new VehicleLocationRecordCacheImpl();
+    VehicleLocationRecord vlr = new VehicleLocationRecord();
+    vlr.setBlockId(blockLocationB.getBlockInstance().getBlock().getBlock().getId());
+    vlr.setTripId(mTripA.getId());
+    vlr.setTimepointPredictions(blockLocationB.getTimepointPredictions());
+    vlr.setTimeOfRecord(mCurrentTime);
+    vlr.setVehicleId(new AgencyAndId("1", "123"));
+
+    // Create ScheduledBlockLocation for cache
+    ScheduledBlockLocation sbl = new ScheduledBlockLocation();
+    sbl.setActiveTrip(blockLocationB.getActiveTrip());
+
+    // Add data to cache
+    _cache.addRecord(blockInstance, vlr, sbl, null);
+    _blockLocationService.setVehicleLocationRecordCache(_cache);
+    ScheduledBlockLocationServiceImpl scheduledBlockLocationServiceImpl = new ScheduledBlockLocationServiceImpl();
+    _blockLocationService.setScheduledBlockLocationService(scheduledBlockLocationServiceImpl);
+
+    // Call ArrivalAndDepartureService
+    return _service.getArrivalsAndDeparturesForStopInTimeRange(mStopB, target,
+        stopTimeFrom, stopTimeTo);
+  }
+
+  //
+  // Helper methods
+  //
+
+  private long getPredictedArrivalTimeByStopId(
+      List<ArrivalAndDepartureInstance> arrivalsAndDepartures,
+      AgencyAndId stopId) {
+    for (ArrivalAndDepartureInstance adi : arrivalsAndDepartures) {
+      if (adi.getStop().getId().equals(stopId)) {
+        return adi.getPredictedArrivalTime();
+      }
+    }
+    return 0;
+  }
+
+  private long getPredictedDepartureTimeByStopId(
+      List<ArrivalAndDepartureInstance> arrivalsAndDepartures,
+      AgencyAndId stopId) {
+    for (ArrivalAndDepartureInstance adi : arrivalsAndDepartures) {
+      if (adi.getStop().getId().equals(stopId)) {
+        return adi.getPredictedDepartureTime();
+      }
+    }
+    return 0;
+  }
+
+  private long getScheduledArrivalTimeByStopId(TripEntryImpl trip,
+      AgencyAndId id) {
+    for (StopTimeEntry ste : trip.getStopTimes()) {
+      if (ste.getStop().getId().equals(id)) {
+        return ste.getArrivalTime() + mServiceDate / 1000;
+      }
+    }
+    return 0;
+  }
+
+  private long getScheduledDepartureTimeByStopId(TripEntryImpl trip,
+      AgencyAndId id) {
+    for (StopTimeEntry ste : trip.getStopTimes()) {
+      if (ste.getStop().getId().equals(id)) {
+        return ste.getDepartureTime() + mServiceDate / 1000;
+      }
+    }
+    return 0;
+  }
+
+  private long createPredictedTime(int time) {
+    return (mServiceDate / 1000 + time) * 1000;
+  }
+}

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TimepointPredictionBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/trips/TimepointPredictionBean.java
@@ -1,5 +1,6 @@
 /**
  * Copyright (C) 2013 Kurt Raschke <kurt@kurtraschke.com>
+ * Copyright (C) 2015 University of South Florida
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,13 +20,19 @@ import java.io.Serializable;
 
 public class TimepointPredictionBean implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private String timepointId;
 
+  private String tripId;
+  
+  private int stopSequence = -1;
+  
   private long timepointScheduledTime;
 
-  private long timepointPredictedTime;
+  private long timepointPredictedArrivalTime = -1;
+
+  private long timepointPredictedDepartureTime = -1;
 
   public TimepointPredictionBean() {
 
@@ -47,11 +54,36 @@ public class TimepointPredictionBean implements Serializable {
     this.timepointScheduledTime = timepointScheduledTime;
   }
 
-  public long getTimepointPredictedTime() {
-    return timepointPredictedTime;
+  public String getTripId() {
+	  return tripId;
   }
 
-  public void setTimepointPredictedTime(long timepointPredictedTime) {
-    this.timepointPredictedTime = timepointPredictedTime;
+  public void setTripId(String tripId) {
+	  this.tripId = tripId;
+  }
+
+  public int getStopSequence() {
+	  return stopSequence;
+  }
+
+  public void setStopSequence(int stopSequence) {
+	  this.stopSequence = stopSequence;
+  }
+
+  public long getTimepointPredictedArrivalTime() {
+	  return timepointPredictedArrivalTime;
+  }
+
+  public void setTimepointPredictedArrivalTime(long timepointPredictedArrivalTime) {
+	  this.timepointPredictedArrivalTime = timepointPredictedArrivalTime;
+  }
+
+  public long getTimepointPredictedDepartureTime() {
+	  return timepointPredictedDepartureTime;
+  }
+
+  public void setTimepointPredictedDepartureTime(
+		  long timepointPredictedDepartureTime) {
+	  this.timepointPredictedDepartureTime = timepointPredictedDepartureTime;
   }
 }


### PR DESCRIPTION
This PR includes several commits that provide targeted fixes for issues #127, #138, and #139, in order to properly support multiple `stop_time_updates` for a single trip from a GTFS-rt source.  This is follow-on work to https://github.com/OneBusAway/onebusaway-application-modules/commit/ad8870b6961add5fa004b9c5ceb7df9a26c51fff, which enabled the consumption of multiple `stop_time_updates` for a single trip from a GTFS-rt source.  This PR focuses on the proper generation of predicted arrival and departure times for each stop, based on the GTFS-rt input.  Some of the source code to support per-stop predictions internally in OBA was already in place even prior to the above patch (including the code to figure out which stop deviation should be applied to a given stop), and this PR brings everything together in working order.  It also adds a significant amount of documentation via comments and Javadocs to better explain what's happening in plain English.

We also include a number of tests for `ArrivalAndDepartureServiceImpl` in `ArrivalAndDepartureServiceImplTest` (via 1a74a49f42cfde389179f90a97c70cdcc4cdcbda) to ensure that the predicted arrival and departure times provided by `ArrivalAndDepartureServiceImpl` are correct, given a set of input time point predictions for one or more stops.  This includes verifying that the behavior of OBA is consistent with the GTFS-rt spec, especially for the propagation of arrival/departure times downstream in a trip.  We include multiple commits in this PR because they are interrelated, and all are needed for the tests to pass.

It should be noted that this implementation of per-stop predictions is used to produce arrival/departure times even if a GTFS-rt source only provides a single prediction for a trip - in other words, single predictions per trip are just a special case of multiple stop predictions per trip where n is the number of per stop predictions, and n = 1.

One additional item of note - as mentioned above, we built on existing OBA code to support multiple predictions per trip, which was our least invasive option.  This code therefore keeps the original OBA internal data model of supporting one deviation per stop.  As a result, there are two situations (marked by `TODO` statements in `ArrivalAndDepartureServiceImplTest`) where OBA can't entirely represent both arrival and departure information correctly for the same stop.  We include two commented-out unit tests for these situations, which can be uncommented if future works overhauls the OBA internal model to fully support arrival and departure deviations for each stop.  Specifically, these situations that aren't supported are:

1. A departure prediction is provided for Stop A, but no arrival prediction is provided for Stop A, and the predicted arrival for Stop A is requested
2. Both arrival and departure predictions (which have different deviations) are provided for Stop A, and the predicted arrival for Stop A is requested

In both cases, the departure prediction deviation (which is predicted_departure - scheduled_departure) would be returned as the arrival prediction deviation.  This is because if we can only support one deviation per stop, we should prefer departure deviation so it's propagated downstream.  I don't believe the current OBA UIs and apps would even expose this limitation, as they show departure info when its provided (but someone correct me if I'm wrong).  So, for us, the risks and amount of work required to overhaul the entire internal OBA data model far surpassed the need to try and fix these two corner cases.  We do include the (commented out) unit tests to verify correct behavior for these two cases, though, if this problem is tackled in the future.

Finally, I want to say a huge thanks to @cagryInside, who spent a lot of time debugging OBA so we could better understand what was happening inside OBA.  This PR definitely wouldn't have been possible without him!

We'd love to get feedback on this, especially from @bdferris @kurtraschke and @sheldonabrown.  We've been testing this with real data in Tampa, and we'll continue to test more heavily in the upcoming weeks.  If anyone else has access to real GTFS-rt feeds (or another data source format) that provides multiple stop predictions per trip, it would be great if you could test this out as well, or at least provide us with the feeds so we can take a look.