### PR TITLE
Update Travis configuration for container-based build and Maven caching.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,5 @@
 language: java
+sudo: false
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI has a new [container-based build infrastructure](http://docs.travis-ci.com/user/migrating-from-legacy/) and [support for caching artifacts between builds](http://docs.travis-ci.com/user/caching/).

This PR enables both, which should speed up builds due to the new infrastructure and due to Maven not having to redownload artifacts for dependencies after the first build.