### PR TITLE
Update API keys embedded in the quickstart and sync between the two quickstart builds.

### DIFF
--- a/onebusaway-quickstart/onebusaway-quickstart-assembly/src/main/assembly/onebusaway-quickstart-api-webapp/WEB-INF/classes/data-sources.xml
+++ b/onebusaway-quickstart/onebusaway-quickstart-assembly/src/main/assembly/onebusaway-quickstart-api-webapp/WEB-INF/classes/data-sources.xml
@@ -36,13 +36,25 @@
     <property name="password" value="password"/>
     <property name="admin" value="true"/>
   </bean>
-  
+
   <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
     <property name="key" value="TEST"/>
   </bean>
-  
+
   <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
     <property name="key" value="org.onebusaway.iphone"/>
+  </bean>
+
+  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
+    <property name="key" value="v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc=cGF1bGN3YXR0c0BnbWFpbC5jb20="/>
+  </bean>
+
+  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
+    <property name="key" value="v1_C5+aiesgg8DxpmG1yS2F/pj2zHk=c3BoZW5yeUBnbWFpbC5jb20=="/>
+  </bean>
+
+  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
+    <property name="key" value="693c0a55-9ef0-4302-8bc3-f9b2db93e124"/>
   </bean>
 
   <bean id="externalGeocoderImpl" class="org.onebusaway.geocoder.impl.DatabaseCachingGeocoderImpl">

--- a/onebusaway-quickstart/onebusaway-quickstart-assembly/src/main/assembly/onebusaway-quickstart-webapp/WEB-INF/classes/data-sources.xml
+++ b/onebusaway-quickstart/onebusaway-quickstart-assembly/src/main/assembly/onebusaway-quickstart-webapp/WEB-INF/classes/data-sources.xml
@@ -19,6 +19,26 @@
     <property name="admin" value="true" />
   </bean>
 
+  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
+    <property name="key" value="TEST"/>
+  </bean>
+
+  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
+    <property name="key" value="org.onebusaway.iphone"/>
+  </bean>
+
+  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
+    <property name="key" value="v1_BktoDJ2gJlu6nLM6LsT9H8IUbWc=cGF1bGN3YXR0c0BnbWFpbC5jb20="/>
+  </bean>
+
+  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
+    <property name="key" value="v1_C5+aiesgg8DxpmG1yS2F/pj2zHk=c3BoZW5yeUBnbWFpbC5jb20=="/>
+  </bean>
+
+  <bean class="org.onebusaway.users.impl.CreateApiKeyAction">
+    <property name="key" value="693c0a55-9ef0-4302-8bc3-f9b2db93e124"/>
+  </bean>
+
   <bean id="externalGeocoderImpl" class="org.onebusaway.geocoder.impl.DatabaseCachingGeocoderImpl">
     <property name="geocoderService">
       <bean class="org.onebusaway.geocoder.impl.YahooGeocoderImpl">


### PR DESCRIPTION
As described in #145, the API+webapp build of the quickstart lacks the pre-loaded API keys that the API-only build contains, and both builds lack keys for the newer mobile apps.

This PR syncs the keys between the two builds, and adds all of the remaining keys listed [here](https://github.com/OneBusAway/onebusaway-application-modules/wiki/Mobile-App-Design-Considerations), so that the quickstart can be used out-of-the-box with any of the mobile apps.