### PR TITLE
Link fixes and minor cleanup in documentation.

### DIFF
--- a/src/site/markdown/api/where/elements/arrival-and-departure.md
+++ b/src/site/markdown/api/where/elements/arrival-and-departure.md
@@ -36,10 +36,10 @@ The `<arrivalAndDeparture/>` element captures information about the arrival and 
 
 * routeId - the route id for the arriving vehicle
 * tripId - the trip id for the arriving vehicle
-* serviceDate - time, in ms since the unix epoch, of midnight for start of the service date for the trip. See the [Glossary#Service_Date glossary entry] for more info
+* serviceDate - time, in ms since the unix epoch, of midnight for start of the service date for the trip.
 * stopId - the stop id of the stop the vehicle is arriving at
 * stopSequence - the index of the stop into the sequence of stops that make up the trip for this arrival
-* blockTripSequence - the index of this arrival's trip into the sequence of trips for the active block.  Compare to `blockTripSequence` in the [OneBusAwayRestApi_TripStatusElementV2 tripStatus element] to determine where the arrival-and-departure is on the block in comparison to the active block location.
+* blockTripSequence - the index of this arrival's trip into the sequence of trips for the active block.  Compare to `blockTripSequence` in the [`<tripStatus/>` element](trip-status.html) to determine where the arrival-and-departure is on the block in comparison to the active block location.
 * routeShortName - the route short name that potentially overrides the route short name in the referenced [`<route/>` element](route.html) - *OPTIONAL*
 * routeLongName - the route long name that potentially overrides the route long name in the referenced [`<route/>` element](route.html) - *OPTIONAL*
 * tripHeadsign - the trip headsign that potentially overrides the trip headsign in the referenced [`<trip/>` element](trip.html) - *OPTIONAL*
@@ -49,8 +49,8 @@ The `<arrivalAndDeparture/>` element captures information about the arrival and 
 * scheduledDepartureTime - scheduled departure time, ms since unix epoch
 * frequency - information about [frequency based scheduling](frequency.html), if applicable to the trip - *OPTIONAL*
 * predicted - true if we have real-time arrival info available for this trip
-* predictedArrivalTime - predicted arrival time, ms since unix epoch, zero if no real-time avaialable
-* predictedDepartureTime - predicted departure time, ms since unix epoch, zero if no real-time avaialable
+* predictedArrivalTime - predicted arrival time, ms since unix epoch, zero if no real-time available
+* predictedDepartureTime - predicted departure time, ms since unix epoch, zero if no real-time available
 * distanceFromStop - distance of the arriving transit vehicle from the stop, in meters
 * numberOfStopsAway - the number of stops between the arriving transit vehicle and the current stop (doesn't include the current stop)
 * tripStatus - [`<tripStatus/>` element](trip-status.html) giving trip-specific status for the arriving transit vehicle - *OPTIONAL*
@@ -59,4 +59,4 @@ The `<arrivalAndDeparture/>` element captures information about the arrival and 
 
 It's important to note that the active trip contained in the `<tripStatus/>` element may be different than the `tripId` specified in the `<arrivalAndDeparture/>`, especially in the case of blocks of trips where the vehicle is currently servicing the previous trip that will link to the trip that will ultimately service the current stop.
 
-In order to support frequency-based scheduling in legacy clients, we will set the `scheduledArrivalTime` and `scheduledDepartureTime` to be the current time + the headway for frequency-based scheduled trips.  Hopefully, we'll be able to add real-time arrival information for all frequency-based routes so that we can provide an actual arrival time.
+In order to support frequency-based scheduling in legacy clients, we will set the `scheduledArrivalTime` and `scheduledDepartureTime` to be the current time + the headway for frequency-based scheduled trips.

--- a/src/site/markdown/api/where/elements/list-result.md
+++ b/src/site/markdown/api/where/elements/list-result.md
@@ -2,7 +2,7 @@
 
 # The List Result
 
-Many api methods return a list of elements as their response.  There are a couple of common request parameters and response elements to consider for these methods.
+Many API methods return a list of elements as their response.  There are a couple of common request parameters and response elements to consider for these methods.
 
 ## Request
 
@@ -14,7 +14,7 @@ The response is composed of two elements.  The first, `<list/>`, is the actual l
 
 Additionally, the list response will have a `<limitExceeded/>` element, which a single true or false value.  This value will be true if the number of elements that could have been potentially returned exceeded the limit sent by `maxCount`, either explicitly or the default value.
 
-Finally, some responses will also include an `<outOfRange/>` element, which will indicate if the search request was made outside the current areas of service for OneBusAway (see [OneBusAwayRestApi_AgenciesWithCoverage agencies-with-coverage]).  The following geographic query methods currently include the `<outOfRange/>` element:
+Finally, some responses will also include an `<outOfRange/>` element, which will indicate if the search request was made outside the current areas of service for OneBusAway (see [agencies-with-coverage](../methods/agencies-with-coverage.html)).  The following geographic query methods currently include the `<outOfRange/>` element:
 
 * [routes-for-location](../methods/routes-for-location.html)
 * [stops-for-location](../methods/stops-for-location.html)

--- a/src/site/markdown/api/where/elements/route.md
+++ b/src/site/markdown/api/where/elements/route.md
@@ -25,4 +25,4 @@ The fields of the route element closely match the fields defined for routes in t
 A few important details:
 
 * The only fields that are absolutely required are `id`, `type` and `agencyId`.
-* Agencies are not required to specify both a shortName and longName, thought they must specify at least one.  Some will specify one but not the other.  Others will include both.  Confounding matters even more, some agencies (ahem King County Metro) don't specify a longName but do specify a description that's effectively a longName.  The result is that care must be taken when constructing a route name by using the information that you're actually given.
+* Agencies are not required to specify both a shortName and longName, thought they must specify at least one.  Some will specify one but not the other.  Others will include both.  Confounding matters even more, some agencies don't specify a longName but do specify a description that's effectively a longName.  The result is that care must be taken when constructing a route name by using the information that you're actually given.

--- a/src/site/markdown/api/where/elements/situation.md
+++ b/src/site/markdown/api/where/elements/situation.md
@@ -4,15 +4,9 @@
 
 Real-time arrival information for public transit vehicles is one of the key pieces of information provided by OneBusAway, but it's only a part of the picture.  Information about cancellations, detours, and explanations for why a transit vehicle is delayed are critical details for riders.  While transit agencies have made some progress in publishing timely emails, SMS, and web notifications about service alert information, we think these approaches are generally too broad.  We want to provide targeted service alerts through OneBusAway that tell you service alert information for just the transit services you are actively using.
 
-Service alerts can encompass a lot of different scenarios, and while we eventually hope to support them all, we're starting a specific use-case: adverse weather reroutes.  Winter is rapidly approaching in the Pacific Northwest and the word on the street is that it's going to be a big snow year.  Snow and public transit generally make for a volatile mix, with local transit agencies having a difficult time communicating information about adverse weather reroutes and cancellations to riders where they need it most: waiting at a stop.
-
-There are a number of issues beyond the scope of this document that we won't address here: the need for GPS vehicle tracking and a better radio network in KCM, or stream-lined rider communication within the agency.
-
-Instead, we'll talk about extensions to the API to support service alert information and how those service alerts will be activated automatically.
-
 ## API Representation
 
-We introduce a new `<situation/>` element.  It's closely modeled on the PtSituation model from the SIRI Situation Exchange protocol (see http://www.kizoom.com/standards/siri/ for more details on the SIRI specification for exchanging real-time transit info).  Let's see an example:
+We introduce a new `<situation/>` element.  It's closely modeled on the PtSituation model from the [SIRI](http://user47094.vs.easily.co.uk/siri/) Situation Exchange schema.  Let's see an example:
 
     <situation>
       <id>1_1289972401385</id>
@@ -76,7 +70,7 @@ The `<situation/>` element can be broken up into a couple of relevant sections:
 The `<affects/>` element captures information about what transit entities are affected by a particular situation.  Right now it supports two sub-elements:
 
 * `stops` - transit stops
-* `vehicleJournerys` - transit vehicle journeys
+* `vehicleJourneys` - transit vehicle journeys
 
 The `<stops/>` element has `<stop>` sub-elements:
 
@@ -99,7 +93,7 @@ The `<vehicleJourneys/>` element has `<vehicleJourney/>` sub-elements:
 
 The `<vehicleJourney/>` element has the following properties:
 
-  * `lineId` - this is equivalent to a route id (I have good reasons for not calling it routeId that I'm happy to discuss offline)
+  * `lineId` - this is equivalent to a route id
   * `direction` - an optional direction id specifying the direction of travel
   * `calls` - optional elements specifying specific stops along the vehicle journey that are affected
 
@@ -152,7 +146,3 @@ If a situation affects a stop directly (as opposed to the routes serving that st
 ### Trip-Specific Situations
 
 If a situation affects a specific trip or a call (an arrival/departure) at a stop by a specific trip, it will appear in the `<situationIds/>` element of the `<arrivalsAndDepartures/>` element.
-
-## Automating Service Alerts
-
-Exposing service alerts in the !OneBusAway API is a good first step, but the service alerts are only as good as the data powering them.  We are actively working with King County Metro and Pierce Transit on an automated system to active adverse reroutes automatically as they are activated in each agency's own customer information systems.  More details on that as they become available.

--- a/src/site/markdown/api/where/elements/trip-details.md
+++ b/src/site/markdown/api/where/elements/trip-details.md
@@ -4,7 +4,7 @@
 
 The `<tripDetails/>` element captures extended information about a particular
 trip, potentially including the trip instance information, schedule, status, and
-active service alert information.  It is returned as a sub-element in a number of api calls.  For example:
+active service alert information.  It is returned as a sub-element in a number of API calls.  For example:
 
 * [trip-details](../methods/trip-details.html)
 * [trip-for-vehicle](../methods/trip-for-vehicle.html)

--- a/src/site/markdown/api/where/elements/trip-status.md
+++ b/src/site/markdown/api/where/elements/trip-status.md
@@ -2,7 +2,7 @@
 
 # The &lt;tripStatus/&gt; Element
 
-The `<tripStatus/>` element captures information about the current status of a transit vehicle serving a trip.  It is returned as a sub-element in a number of api calls.  For example:
+The `<tripStatus/>` element captures information about the current status of a transit vehicle serving a trip.  It is returned as a sub-element in a number of API calls.  For example:
 
 * [arrivals-and-departures-for-stop](../methods/arrivals-and-departures-for-stop.html)
 * Any method that returns a [`<tripDetails/>` element](trip-details.html).
@@ -48,9 +48,9 @@ The `<tripStatus/>` element captures information about the current status of a t
 ## Details
 
 * activeTripId - the trip id of the trip the vehicle is actively serving.  All trip-specific values will be in reference to this active trip
-* blockTripSequence - the index of the active trip into the sequence of trips for the active block.  Compare to `blockTripSequence` in the [OneBusAwayRestApi_ArrivalAndDepartureElementV2 arrivalAndDeparture element] to determine where the active block location is relative to an arrival-and-departure.
-* serviceDate - time, in ms since the unix epoch, of midnight for start of the service date for the trip. See the [Glossary#Service_Date glossary entry] for more info
-* frequency - information about [OneBusAwayRestApi_FrequencyElementV2 frequency based scheduling], if applicable to the trip - *OPTIONAL*
+* blockTripSequence - the index of the active trip into the sequence of trips for the active block.  Compare to `blockTripSequence` in the [`<arrivalAndDeparture/>` element](arrival-and-departure.html) to determine where the active block location is relative to an arrival-and-departure.
+* serviceDate - time, in ms since the unix epoch, of midnight for start of the service date for the trip.
+* frequency - information about [frequency based scheduling](frequency.html), if applicable to the trip - *OPTIONAL*
 * scheduledDistanceAlongTrip - the distance, in meters, the transit vehicle is scheduled to have progress along the active trip.  This is an optional value, and will only be present if the trip is in progress. *OPTIONAL*
 * totalDistanceAlongTrip - the total length of the trip, in meters
 * position - current position of the transit vehicle. This element is optional, and will only be present if the trip is actively running. If real-time arrival data is available, the position will take that into account, otherwise the position reflects the scheduled position of the vehicle. *OPTIONAL*
@@ -69,4 +69,4 @@ The `<tripStatus/>` element captures information about the current status of a t
 * distanceAlongTrip - the distance, in meters, the transit vehicle has progressed along the active trip.  This is an optional value that will only be present if the underlying AVL system supplies it and is potential extrapolated from the last known reading to the current time.
 * scheduleDeviation - if real-time arrival info is available, this lists the deviation from the schedule in seconds, where positive number indicates the trip is running late and negative indicates the trips is running early. If not real-time arrival info is available, this will be zero.
 * vehicleId - if real-time arrival info is available, this lists the id of the transit vehicle currently running the trip. *OPTIONAL*
-* situationIds - references to [OneBusAwayRestApi_SituationElementV2 situation elements], for active service alerts applicable to this trip. *OPTIONAL*
+* situationIds - references to [`<situation/>` elements](situation.html), for active service alerts applicable to this trip. *OPTIONAL*

--- a/src/site/markdown/api/where/index.md
+++ b/src/site/markdown/api/where/index.md
@@ -136,7 +136,7 @@ The current list of supported API methods.  Methods that are subject to changed 
 
 ## Common Elements
 
-See more discussion of [OneBusAwayRestApi_Version2 Version 2] of the api and how element references have changed:
+See more discussion of Version 2 of the API and how element references have changed:
 
 * [agency](elements/agency.html)
 * [arrivalAndDeparture](elements/arrival-and-departure.html)

--- a/src/site/markdown/api/where/methods/agency.md
+++ b/src/site/markdown/api/where/methods/agency.md
@@ -31,7 +31,7 @@ http://api.pugetsound.onebusaway.org/api/where/agency/1.xml?key=TEST
 
 ## Request Parameters
 
-* id - the id of the agency, encoded directly in the url:
+* id - the id of the agency, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/agency/[ID GOES HERE].xml`
 
 ### Response

--- a/src/site/markdown/api/where/methods/arrival-and-departure-for-stop.md
+++ b/src/site/markdown/api/where/methods/arrival-and-departure-for-stop.md
@@ -25,7 +25,7 @@ http://api.pugetsound.onebusaway.org/api/where/arrival-and-departure-for-stop/1_
 
 ## Request Parameters
 
-* id - the stop id, encoded directly in the url:
+* id - the stop id, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/arrival-and-departure-for-stop/[ID GOES HERE].xml`
 * tripId - the trip id of the arriving transit vehicle
 * serviceDate - the service date of the arriving transit vehicle

--- a/src/site/markdown/api/where/methods/arrivals-and-departures-for-stop.md
+++ b/src/site/markdown/api/where/methods/arrivals-and-departures-for-stop.md
@@ -34,7 +34,7 @@ http://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/
 
 ## Request Parameters
 
-* id - the stop id, encoded directly in the url:
+* id - the stop id, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/arrivals-and-departures-for-stop/[ID GOES HERE].xml`
 * minutesBefore=n - include vehicles having arrived or departed in the previous n minutes (default=5)
 * minutesAfter=n - include vehicles arriving or departing in the next n minutes (default=35)

--- a/src/site/markdown/api/where/methods/cancel-alarm.md
+++ b/src/site/markdown/api/where/methods/cancel-alarm.md
@@ -25,4 +25,4 @@ http://api.pugetsound.onebusaway.org/api/where/cancel_alarm/1_00859082-9b9d-4f72
 * id - the alarm id is encoded directly in the URL
     * `http://api.pugetsound.onebusaway.org/api/where/cancel_alarm/[ID GOES HERE].xml`
 
-The alarm id is returned in the call to [register-alarm-for-arrival-and-departure-at-stop](register-alarm-for-arrival-and-departure-at-stop.html) api method.
+The alarm id is returned in the call to [register-alarm-for-arrival-and-departure-at-stop](register-alarm-for-arrival-and-departure-at-stop.html) API method.

--- a/src/site/markdown/api/where/methods/register-alarm-for-arrival-and-departure-at-stop.md
+++ b/src/site/markdown/api/where/methods/register-alarm-for-arrival-and-departure-at-stop.md
@@ -2,7 +2,7 @@
 
 # Method: register-alarm-for-arrival-and-departure-at-stop
 
-Register an alarm for a single arrival and departure at a stop, with a callback url to be requested when the alarm is fired.
+Register an alarm for a single arrival and departure at a stop, with a callback URL to be requested when the alarm is fired.
 
 ## Sample Request
 
@@ -27,12 +27,12 @@ http://api.pugetsound.onebusaway.org/api/where/register-alarm-for-arrival-and-de
 
 ## Request Parameters
 
-* id, tripId, serviceDate, vehicleId, stopSequence - see discussion in [arrival-and-departure-for-stop api call](arrival-and-departure-for-stop.html) for discussion of how to specify a particular arrival or departure
-* url - callback url that will be requested when the alarm is fired
+* id, tripId, serviceDate, vehicleId, stopSequence - see discussion in [arrival-and-departure-for-stop](arrival-and-departure-for-stop.html) API method for discussion of how to specify a particular arrival or departure
+* url - callback URL that will be requested when the alarm is fired
 * alarmTimeOffset - time, in seconds, that controls how long before the arrival/departure the alarm will be fired.  Default is zero.
 * onArrival - set to true to indicate the alarm should be fired relative to vehicle arrival, false for departure.  The default is false for departure.
 
-We provide an arrival-departure alarm callback mechanism that allows you to register an alarm for an arrival or departure event and received a callback in the form of a GET request to a url you specify.
+We provide an arrival-departure alarm callback mechanism that allows you to register an alarm for an arrival or departure event and received a callback in the form of a GET request to a URL you specify.
 
 In order to specify an alarm for something like "5 minutes before a bus departs, we provide the `alarmTimeOffset` which specifies when the alarm should be fired relative to the actual arrival or departure event.  A value of 60 indicates that the alarm should be fired 60 seconds before, while a value of -30 would be fired 30 seconds after.
 
@@ -40,6 +40,6 @@ In order to specify an alarm for something like "5 minutes before a bus departs,
 
 ## Response
 
-The response is the alarm id.  Note that if you include `#ALARM_ID#` anywhere in your callback url, we will automatically replace it with the id of the alarm being fired.  This can be useful when you register multiple alarms and need to be able to distinguish between them.
+The response is the alarm id.  Note that if you include `#ALARM_ID#` anywhere in your callback URL, we will automatically replace it with the id of the alarm being fired.  This can be useful when you register multiple alarms and need to be able to distinguish between them.
 
-Also see the [cancel-alarm](cancel-alarm.html) api method, which also accepts the alarm id as an argument.
+Also see the [cancel-alarm](cancel-alarm.html) API method, which also accepts the alarm id as an argument.

--- a/src/site/markdown/api/where/methods/report-problem-with-stop.md
+++ b/src/site/markdown/api/where/methods/report-problem-with-stop.md
@@ -25,7 +25,7 @@ http://api.pugetsound.onebusaway.org/api/where/report-problem-with-stop/1_75403.
 
 ## Request Parameters
 
-* stopId - the trip id, encoded directly in the url:
+* stopId - the trip id, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/report-problem-with-stop/[ID GOES HERE].xml`
 * code - a string code identifying the nature of the problem
     * `stop_name_wrong` - the stop name in OneBusAway differs from the actual stop's name

--- a/src/site/markdown/api/where/methods/report-problem-with-trip.md
+++ b/src/site/markdown/api/where/methods/report-problem-with-trip.md
@@ -25,7 +25,7 @@ http://api.pugetsound.onebusaway.org/api/where/report-problem-with-trip/1_794302
 
 ## Request Parameters
 
-* tripId - the trip id, encoded directly in the url:
+* tripId - the trip id, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/report-problem-with-trip/[ID GOES HERE].xml`
 * serviceDate - the service date of the trip
 * vehicleId - the vehicle actively serving the trip

--- a/src/site/markdown/api/where/methods/route-ids-for-agency.md
+++ b/src/site/markdown/api/where/methods/route-ids-for-agency.md
@@ -29,7 +29,7 @@ http://api.pugetsound.onebusaway.org/api/where/route-ids-for-agency/40.xml?key=T
 
 ## Request Parameters
 
-* id - the id of the agency, encoded directly in the url:
+* id - the id of the agency, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/route-ids-for-agency/[ID GOES HERE].xml?key=TEST`
 
 ## Response

--- a/src/site/markdown/api/where/methods/route.md
+++ b/src/site/markdown/api/where/methods/route.md
@@ -31,7 +31,7 @@ http://api.pugetsound.onebusaway.org/api/where/route/1_44.xml?key=TEST
 
 ## Request Parameters
 
-* `id` - the id of the route, encoded directly in the url
+* `id` - the id of the route, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/route/[ID GOES HERE].xml`
 
 ## Response

--- a/src/site/markdown/api/where/methods/routes-for-agency.md
+++ b/src/site/markdown/api/where/methods/routes-for-agency.md
@@ -34,7 +34,7 @@ http://api.pugetsound.onebusaway.org/api/where/routes-for-agency/1.xml?key=TEST
 
 ## Request Parameters
 
-* id - the id of the agency, encoded in the url directly
+* id - the id of the agency, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/routes-for-agency/[ID GOES HERE].xml`
 
 ## Response

--- a/src/site/markdown/api/where/methods/schedule-for-stop.md
+++ b/src/site/markdown/api/where/methods/schedule-for-stop.md
@@ -55,7 +55,7 @@ http://api.pugetsound.onebusaway.org/api/where/schedule-for-stop/1_75403.xml?key
 
 ## Request Parameters
 
-* id - encoded in the url directly, this specifies the stop id to request the schedule for
+* id - the stop id to request the schedule for, encoded directly in the URL:
 	* `http://api.pugetsound.onebusaway.org/api/where/schedule-for-stop/[ID GOES HERE].xml`
 * date - The date for which you want to request a schedule of the format YYYY-MM-DD (optional, defaults to current date)
 
@@ -72,7 +72,7 @@ Finally we get down to the unit of a stop time, as represented by the `<schedule
 * arrivalTime - time in milliseconds since the Unix epoch that the transit vehicle will arrive
 * departureTime - time in milliseconds since the Unix epoch that the transit vehicle will depart
 * tripId - the id for the trip of the scheduled transit vehicle
-* serviceId - the serviceId for the schedule trip (see the [http://code.google.com/transit/spec/transit_feed_specification.html GTFS spec] for more details
+* serviceId - the serviceId for the schedule trip (see the [GTFS spec](http://code.google.com/transit/spec/transit_feed_specification.html) for more details
 
 In addition to all the `<scheduleStopTime/>` elements, the response also contains `<stopCalendarDay/>` elements which list out all the days that a particular stop has service.  This element has the following properties:
 

--- a/src/site/markdown/api/where/methods/shape.md
+++ b/src/site/markdown/api/where/methods/shape.md
@@ -36,9 +36,9 @@ http://api.pugetsound.onebusaway.org/api/where/shape/1_40046045.xml?key=TEST
 
 ## Request Parameters
 
-* `id` - the shape id is included directly in the url path
+* `id` - the shape id, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/shape/[ID GOES HERE].xml`
 
 ## Response
 
-The path is returned as a `<shape/>` element with a points in the [http://code.google.com/apis/maps/documentation/polylinealgorithm.html encoded polyline format] defined for Google Maps.
+The path is returned as a `<shape/>` element with a points in the [encoded polyline format](http://code.google.com/apis/maps/documentation/polylinealgorithm.html) defined for Google Maps.

--- a/src/site/markdown/api/where/methods/stop-ids-for-agency.md
+++ b/src/site/markdown/api/where/methods/stop-ids-for-agency.md
@@ -29,7 +29,7 @@ http://api.pugetsound.onebusaway.org/api/where/stop-ids-for-agency/40.xml?key=TE
 
 ## Request Parameters
 
-* id - the id of the agency, encoded directly in the url:
+* id - the id of the agency, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/stop-ids-for-agency/[ID GOES HERE].xml`
 
 ## Response

--- a/src/site/markdown/api/where/methods/stop.md
+++ b/src/site/markdown/api/where/methods/stop.md
@@ -35,7 +35,7 @@ http://api.pugetsound.onebusaway.org/api/where/stop/1_75403.xml?key=TEST
 
 ## Request Parameters
 
-* `id` - the id of the requested stop, encoded directly in the url:
+* `id` - the id of the requested stop, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/stop/[ID GOES HERE].xml` 
 
 ## Response

--- a/src/site/markdown/api/where/methods/stops-for-route.md
+++ b/src/site/markdown/api/where/methods/stops-for-route.md
@@ -57,7 +57,7 @@ http://api.pugetsound.onebusaway.org/api/where/stops-for-route/1_44.xml?key=TEST
 
 ## Request Parameters
 
-* `id` - The route id, encoded directly in the url:
+* `id` - The route id, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/stops-for-route/[ID GOES HERE].xml`
 * includePolylines=true|false = Optional parameter that controls whether polyline elements are included in the response.  Defaults to true.
 

--- a/src/site/markdown/api/where/methods/trip-details.md
+++ b/src/site/markdown/api/where/methods/trip-details.md
@@ -31,7 +31,7 @@ http://api.pugetsound.onebusaway.org/api/where/trip-details/1_12540399.xml?key=T
 
 ## Request Parameters
 
-* id - the id of the trip, encoded directly in the url:
+* id - the id of the trip, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/trip-details/[ID GOES HERE].xml`
 * serviceDate - the service date for the trip as unix-time in ms (optional).  Used to disambiguate different versions of the same trip.  See [Glossary#ServiceDate the glossary entry for service date].
 * includeTrip - Can be true/false to determine whether full [`<trip/>`](../elements/trip.html) element is included in the `<references/>` section.  Defaults to true.

--- a/src/site/markdown/api/where/methods/trip-for-vehicle.md
+++ b/src/site/markdown/api/where/methods/trip-for-vehicle.md
@@ -32,7 +32,7 @@ http://api.pugetsound.onebusaway.org/api/where/trip-for-vehicle/1_4210.xml?key=T
 
 ## Request Parameters
 
-* id - the id of the vehicle, encoded directly in the url:
+* id - the id of the vehicle, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/trip-for-vehicle/[ID GOES HERE].xml`
 * includeTrip - Can be true/false to determine whether full [`<trip/>` element](../elements/trip.html) is included in the `<references/>` section.  Defaults to false.
 * includeSchedule - Can be true/false to determine whether full `<schedule/>` element is included in the `<tripDetails/>` section.  Defaults to fale.

--- a/src/site/markdown/api/where/methods/trip.md
+++ b/src/site/markdown/api/where/methods/trip.md
@@ -31,7 +31,7 @@ http://api.pugetsound.onebusaway.org/api/where/trip/1_12540399.xml?key=TEST
 
 ## Request Parameters
 
-* id - the id of the trip, encoded directly in the url:
+* id - the id of the trip, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/trip/[ID GOES HERE].xml`
 
 ## Response

--- a/src/site/markdown/api/where/methods/trips-for-route.md
+++ b/src/site/markdown/api/where/methods/trips-for-route.md
@@ -30,7 +30,7 @@ http://api.pugetsound.onebusaway.org/api/where/trips-for-route/1_44.xml?key=TEST
 
 ## Request Parameters
 
-* id - the id of the route, encoded directly in the url:
+* id - the id of the route, encoded directly in the URL:
     * `http://api.pugetsound.onebusaway.org/api/where/trips-for-route/[ID GOES HERE].xml`
 * includeStatus - Can be true/false to determine whether full
   [`<tripStatus/>` elements](../elements/trip-status.html) with full real-time

--- a/src/site/markdown/api/where/methods/vehicles-for-agency.md
+++ b/src/site/markdown/api/where/methods/vehicles-for-agency.md
@@ -32,7 +32,7 @@ http://api.onebusaway.org/api/where/vehicles-for-agency/1.xml?key=TEST
 
 ## Request Parameters
 
-* id - the id of the agency, encoded in the url directly
+* id - the id of the agency, encoded directly in the URL:
     * `http://api.onebusaway.org/api/where/vehicles-for-agency/[ID GOES HERE].xml`
 * time - by default, the method returns the status of the system right now.  However, the system
   can also be queried at a specific time.  This can be useful for testing.  See [timestamps](../index.html#Timestamps)


### PR DESCRIPTION
While investigating #145 I came across some broken links in the documentation (apparent remnants from when the documentation used something other than Markdown for formatting).  This PR fixes those as well as a few style issues, etc.