### PR TITLE
Fix #148 - Better support for filtering arrival/departure info at stops

### DIFF
--- a/onebusaway-api-core/src/main/java/org/onebusaway/api/model/transit/ArrivalAndDepartureV2Bean.java
+++ b/onebusaway-api-core/src/main/java/org/onebusaway/api/model/transit/ArrivalAndDepartureV2Bean.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 public class ArrivalAndDepartureV2Bean implements Serializable {
 
-  private static final long serialVersionUID = 2L;
+  private static final long serialVersionUID = 3L;
 
   private String routeId;
 
@@ -77,6 +77,8 @@ public class ArrivalAndDepartureV2Bean implements Serializable {
   private TripStatusV2Bean tripStatus;
 
   private List<String> situationIds;
+  
+  private int totalStopsInTrip;
 
   public String getRouteId() {
     return routeId;
@@ -314,7 +316,15 @@ public class ArrivalAndDepartureV2Bean implements Serializable {
     this.predictedDepartureInterval = predictedDepartureInterval;
   }
 
-  public long computeBestArrivalTime() {
+  public int getTotalStopsInTrip() {
+	return totalStopsInTrip;
+}
+
+public void setTotalStopsInTrip(int totalStopsInTrip) {
+	this.totalStopsInTrip = totalStopsInTrip;
+}
+
+public long computeBestArrivalTime() {
     return hasPredictedArrivalTime() ? getPredictedArrivalTime()
         : getScheduledArrivalTime();
   }

--- a/onebusaway-api-core/src/main/java/org/onebusaway/api/model/transit/BeanFactoryV2.java
+++ b/onebusaway-api-core/src/main/java/org/onebusaway/api/model/transit/BeanFactoryV2.java
@@ -818,7 +818,8 @@ public class BeanFactoryV2 {
     addToReferences(stop);
     bean.setStopSequence(ad.getStopSequence());
     bean.setBlockTripSequence(ad.getBlockTripSequence());
-
+    bean.setTotalStopsInTrip(ad.getTotalStopsInTrip());
+    
     bean.setRouteId(route.getId());
     addToReferences(route);
 

--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopTimeEntriesFactory.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/tasks/transit_graph/StopTimeEntriesFactory.java
@@ -75,8 +75,10 @@ public class StopTimeEntriesFactory {
     List<StopTimeEntryImpl> stopTimeEntries = createInitialStopTimeEntries(
         graph, stopTimes);
 
-    for (StopTimeEntryImpl stopTime : stopTimeEntries)
+    for (StopTimeEntryImpl stopTime : stopTimeEntries) {
       stopTime.setTrip(tripEntry);
+      stopTime.setTotalStopsInTrip(stopTimeEntries.size());
+    }
 
     ensureStopTimesHaveShapeDistanceTraveledSet(stopTimeEntries, shapePoints);
 

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/ArrivalsAndDeparturesBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/ArrivalsAndDeparturesBeanServiceImpl.java
@@ -294,7 +294,8 @@ public class ArrivalsAndDeparturesBeanServiceImpl implements
 
     pab.setStop(stopBean);
     pab.setStopSequence(stopTime.getSequence());
-
+    pab.setTotalStopsInTrip(stopTime.getTotalStopsInTrip());
+    
     pab.setStatus("default");
 
     pab.setScheduledArrivalTime(instance.getScheduledArrivalTime());

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/StopTimeEntryImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/transit_graph/StopTimeEntryImpl.java
@@ -23,7 +23,7 @@ import org.onebusaway.transit_data_federation.services.transit_graph.StopTimeEnt
 
 public class StopTimeEntryImpl implements StopTimeEntry, Serializable {
 
-  private static final long serialVersionUID = 7L;
+  private static final long serialVersionUID = 8L;
 
   private int _stopTimeId;
   private int _arrivalTime;
@@ -35,6 +35,7 @@ public class StopTimeEntryImpl implements StopTimeEntry, Serializable {
   private int _shapePointIndex = -1;
   private double _shapeDistTraveled = Double.NaN;
   private int _accumulatedSlackTime = 0;
+  private int _totalStopsInTrip;
 
   private StopEntryImpl _stop;
 
@@ -97,6 +98,10 @@ public class StopTimeEntryImpl implements StopTimeEntry, Serializable {
 
   public void setAccumulatedSlackTime(int accumulatedSlackTime) {
     _accumulatedSlackTime = accumulatedSlackTime;
+  }
+  
+  public void setTotalStopsInTrip(int totalStopsInTrip) {
+    _totalStopsInTrip = totalStopsInTrip;
   }
 
   /****
@@ -168,6 +173,11 @@ public class StopTimeEntryImpl implements StopTimeEntry, Serializable {
     return _accumulatedSlackTime;
   }
 
+  @Override
+  public int getTotalStopsInTrip() {
+    return _totalStopsInTrip;
+  }
+  
   @Override
   public String toString() {
     return "StopTimeEntryImpl(stop=" + _stop.getId() + " trip=" + _trip

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/transit_graph/StopTimeEntry.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/services/transit_graph/StopTimeEntry.java
@@ -77,4 +77,10 @@ public interface StopTimeEntry {
    * @return the accumulated slack time, in seconds
    */
   public int getAccumulatedSlackTime();
+  
+  /**
+   * 
+   * @return the total number of stops in this trip
+   */
+  public int getTotalStopsInTrip();
 }

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/ArrivalAndDepartureBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/ArrivalAndDepartureBean.java
@@ -25,7 +25,7 @@ import org.onebusaway.transit_data.model.trips.TripStatusBean;
 
 public class ArrivalAndDepartureBean extends ApplicationBean {
 
-  private static final long serialVersionUID = 3L;
+  private static final long serialVersionUID = 4L;
 
   private TripBean trip;
 
@@ -80,6 +80,8 @@ public class ArrivalAndDepartureBean extends ApplicationBean {
   private List<ServiceAlertBean> situations;
 
   private HistogramBean scheduleDeviationHistogram;
+  
+  private int totalStopsInTrip;
 
   public TripBean getTrip() {
     return trip;
@@ -306,7 +308,15 @@ public class ArrivalAndDepartureBean extends ApplicationBean {
     this.scheduleDeviationHistogram = scheduleDeviationHistogram;
   }
 
-  public boolean hasPredictedArrivalTime() {
+  public int getTotalStopsInTrip() {
+	return totalStopsInTrip;
+}
+
+public void setTotalStopsInTrip(int totalStopsInTrip) {
+	this.totalStopsInTrip = totalStopsInTrip;
+}
+
+public boolean hasPredictedArrivalTime() {
     return this.predictedArrivalTime > 0;
   }
 

--- a/src/site/markdown/api/where/elements/arrival-and-departure.md
+++ b/src/site/markdown/api/where/elements/arrival-and-departure.md
@@ -38,7 +38,8 @@ The `<arrivalAndDeparture/>` element captures information about the arrival and 
 * tripId - the trip id for the arriving vehicle
 * serviceDate - time, in ms since the unix epoch, of midnight for start of the service date for the trip. See the [Glossary#Service_Date glossary entry] for more info
 * stopId - the stop id of the stop the vehicle is arriving at
-* stopSequence - the index of the stop into the sequence of stops that make up the trip for this arrival
+* stopSequence - the index of the stop into the sequence of stops that make up the trip for this arrival. This value is 0-indexed, and is generated internally by OneBusAway (it is not the GTFS stop_sequence). The first stop in the trip will always have stopSequence = 0, while the last stop in the trip will always have stopSequence = totalStopsInTrip - 1.
+* totalStopsInTrip - the total number of stops visited on the trip for this arrival. If the same stop is visited more than once in this trip, each visitation is counted towards the total.
 * blockTripSequence - the index of this arrival's trip into the sequence of trips for the active block.  Compare to `blockTripSequence` in the [OneBusAwayRestApi_TripStatusElementV2 tripStatus element] to determine where the arrival-and-departure is on the block in comparison to the active block location.
 * routeShortName - the route short name that potentially overrides the route short name in the referenced [`<route/>` element](route.html) - *OPTIONAL*
 * routeLongName - the route long name that potentially overrides the route long name in the referenced [`<route/>` element](route.html) - *OPTIONAL*


### PR DESCRIPTION
`totalStopsInTrip` was implemented to arrival/departure information.

Following is the example json response from: [api/where/arrivals-and-departures-for-stop/Hillsborough Area Regional Transit_6497.json?key=TEST]()

```
arrivalsAndDepartures": [

{

    "serviceDate": 1441857600000,
    "numberOfStopsAway": -1,
    "vehicleId": "Hillsborough Area Regional Transit_2927",
    "lastUpdateTime": 1441898106873,
    "routeId": "Hillsborough Area Regional Transit_45",
    "frequency": null,
    "stopSequence": 0,

    "totalStopsInTrip": 87,

    "scheduledDepartureInterval": null,
    ...
    ...
    ...
    ...
}

```
