### PR TITLE
Fix parameter names in documentation for trips-for-location and trips-for-route

### DIFF
--- a/src/site/markdown/api/where/methods/trips-for-location.md
+++ b/src/site/markdown/api/where/methods/trips-for-location.md
@@ -33,8 +33,8 @@ http://api.pugetsound.onebusaway.org/api/where/trips-for-location.xml?key=TEST&l
 * lat - The latitude coordinate of the search center
 * lon - The longitude coordinate of the search center
 * latSpan/lonSpan - Set the limits of the search bounding box
-* includeTrips - Can be true/false to determine whether full [`<trip/>` elements](../elements/trip.html) are included in the `<references/>` section.  Defaults to false.
-* includeSchedules - Can be true/false to determine whether full `<schedule/>` elements are included in the `<tripDetails/>` section.  Defaults to false.
+* includeTrip - Can be true/false to determine whether full [`<trip/>` elements](../elements/trip.html) are included in the `<references/>` section.  Defaults to false.
+* includeSchedule - Can be true/false to determine whether full `<schedule/>` elements are included in the `<tripDetails/>` section.  Defaults to false.
 * time - by default, the method returns the status of the system right now.  However, the system
   can also be queried at a specific time.  This can be useful for testing.  See [timestamps](../index.html#Timestamps)
   for details on the format of the `time` parameter.

--- a/src/site/markdown/api/where/methods/trips-for-route.md
+++ b/src/site/markdown/api/where/methods/trips-for-route.md
@@ -36,7 +36,7 @@ http://api.pugetsound.onebusaway.org/api/where/trips-for-route/1_44.xml?key=TEST
   [`<tripStatus/>` elements](../elements/trip-status.html) with full real-time
   information are included in the `<status/>` section for each `<tripDetails/>`
   element.  Defaults to false.
-* includeSchedules - Can be true/false to determine whether full `<schedule/>`
+* includeSchedule - Can be true/false to determine whether full `<schedule/>`
   elements are included in the `<tripDetails/>` element.  Defaults to false.
 * time - by default, the method returns the status of the system right now.  However, the system
   can also be queried at a specific time.  This can be useful for testing.  See [timestamps](../index.html#Timestamps)


### PR DESCRIPTION
As first reported [on the mailing list](https://groups.google.com/d/msg/onebusaway-api/w1-FoJvV8B8/q0nQI5APBQAJ), some parameters in the documentation for the `trips-for-location` and `trips-for-route` API methods are referred to in plural form, whereas the actual parameters (in [`TripsForLocationAction`](https://github.com/OneBusAway/onebusaway-application-modules/blob/3bee16af29cbde556de7eaba59b44c2bfaf411cf/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/TripsForLocationAction.java#L95), [`TripsForRouteAction`](https://github.com/OneBusAway/onebusaway-application-modules/blob/3bee16af29cbde556de7eaba59b44c2bfaf411cf/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/TripsForRouteAction.java#L89)) are singular.