### PR TITLE
Update FederatedTransitDataBundleCreatorMain.java

### DIFF
--- a/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/FederatedTransitDataBundleCreatorMain.java
+++ b/onebusaway-transit-data-federation-builder/src/main/java/org/onebusaway/transit_data_federation/bundle/FederatedTransitDataBundleCreatorMain.java
@@ -230,6 +230,7 @@ public class FederatedTransitDataBundleCreatorMain {
   }
 
   protected void buildOptions(Options options) {
+    options.addOption(ARG_USE_DATABASE_FOR_GTFS, false, "");
     options.addOption(ARG_SKIP_TO, true, "");
     options.addOption(ARG_ONLY, true, "");
     options.addOption(ARG_SKIP, true, "");


### PR DESCRIPTION
ARG_USE_DATABASE_FOR_GTFS option was not eligible through the command line; so the user couldn't store GTFS within a database.