### PR TITLE
Deprecate plan trip API method in documentation

### DIFF
--- a/src/site/markdown/api/where/index.md
+++ b/src/site/markdown/api/where/index.md
@@ -105,7 +105,7 @@ size.
 
 ## Methods
 
-The current list of supported API methods.  Methods that are subject to changed are marked <font color="red">BETA</font>.
+The current list of supported API methods.  Methods that are subject to changed are marked <font color="red">BETA</font>.  Methods that have a ~~strikethrough~~ are deprecated and no longer supported.
 
 * [agencies-with-coverage](methods/agencies-with-coverage.html) - list all supported agencies along with the center of their coverage area
 * [agency](methods/agency.html) - get details for a specific agency
@@ -114,7 +114,7 @@ The current list of supported API methods.  Methods that are subject to changed 
 * [block](methods/block.html) - get block configuration for a specific block
 * [cancel-alarm](methods/cancel-alarm.html) - cancel a registered alarm
 * [current-time](methods/current-time.html) - retrieve the current system time
-* [plan-trip](methods/plan-trip.html) - plan a trip <font color="red">BETA</font>
+* ~~[plan-trip](methods/plan-trip.html) - plan a trip <font color="red">BETA</font>~~ (Check out the [OpenTripPlanner](http://www.opentripplanner.org/) project instead)
 * [register-alarm-for-arrival-and-departure-at-stop](methods/register-alarm-for-arrival-and-departure-at-stop.html) - register an alarm for an arrival-departure event
 * [report-problem-with-stop](methods/report-problem-with-stop.html) - submit a user-generated problem for a stop
 * [report-problem-with-trip](methods/report-problem-with-trip.html) - submit a user-generated problem for a trip

--- a/src/site/markdown/api/where/methods/plan-trip.md
+++ b/src/site/markdown/api/where/methods/plan-trip.md
@@ -1,10 +1,12 @@
 [Back to API parent page](../index.html)
 
-# Method: plan-trip
+# ~~Method: plan-trip~~
 
-<font color="red"><b>This method is currently in BETA and SUBJECT TO CHANGE.</b></font>
+~~This method allows you to plan a trip using public transit between locations.  Detailed information about the sequence of steps for the trip, including walking and transit, are included in the response.  A variety of parameters can be used to control which trip plans are favored in a particular request.~~
 
-This method allows you to plan a trip using public transit between locations.  Detailed information about the sequence of steps for the trip, including walking and transit, are included in the response.  A variety of parameters can be used to control which trip plans are favored in a particular request.
+**This method is deprecated and no longer supported**
+
+Check out the [OpenTripPlanner](http://www.opentripplanner.org/) open-source project for multimodal trip planning capabilities.
 
 ## Sample Request
 


### PR DESCRIPTION
As discussed in https://github.com/OneBusAway/onebusaway-application-modules/issues/44 - Kurt's PR to remove the functionality is in https://github.com/OneBusAway/onebusaway-application-modules/pull/53, but ended up getting merged in camsys/onebusaway-application-modules#2.

This patch updates the documentation hosted at http://developer.onebusaway.org/modules/onebusaway-application-modules/current/api/where/index.html to reflect that the trip planning API is deprecated and should no longer be used.

cc @sheldonabrown @JulietChase