### PR TITLE
Fix #183 getTimeForStopTimeUpdate throws exception if no Arrival and …

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/GtfsRealtimeTripLibrary.java
@@ -488,7 +488,7 @@ class GtfsRealtimeTripLibrary {
       }
     }
 
-    if (stopTimeUpdate.hasStopId()) {
+    if (stopTimeUpdate.hasStopId() && (stopTimeUpdate.hasArrival() || stopTimeUpdate.hasDeparture())) {
       int time = getTimeForStopTimeUpdate(stopTimeUpdate, serviceDate);
       String stopId = stopTimeUpdate.getStopId();
       // There could be loops, meaning a stop could appear multiple times along


### PR DESCRIPTION
Fix for #183 

Just check for at least one of the two properties: hasArrival or hasDeparture of the stopTimeUpdate before calling getTimeForStopTimeUpdate in order to avoid throwing an exception and stopping the whole process.
