### PR TITLE
Fix use of RefreshableResources in WhereGeospatialServiceImpl.

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/WhereGeospatialServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/WhereGeospatialServiceImpl.java
@@ -16,6 +16,7 @@
  */
 package org.onebusaway.transit_data_federation.impl;
 
+import org.onebusaway.container.refresh.RefreshService;
 import org.onebusaway.container.refresh.Refreshable;
 import org.onebusaway.geospatial.model.CoordinateBounds;
 import org.onebusaway.gtfs.model.AgencyAndId;
@@ -46,6 +47,8 @@ class WhereGeospatialServiceImpl implements GeospatialBeanService {
 
   private TransitGraphDao _transitGraphDao;
 
+  private RefreshService _refreshService;
+
   private STRtree _tree;
 
   @Autowired
@@ -53,15 +56,20 @@ class WhereGeospatialServiceImpl implements GeospatialBeanService {
     _transitGraphDao = transitGraphDao;
   }
 
+  @Autowired
+  public void setRefreshService(RefreshService refreshService) {
+    _refreshService = refreshService;
+  }
 
   @PostConstruct
-  @Refreshable(dependsOn = RefreshableResources.STOP_GEOSPATIAL_INDEX)
+  @Refreshable(dependsOn = RefreshableResources.TRANSIT_GRAPH)
   public void initialize() {
 
     List<StopEntry> stops = _transitGraphDao.getAllStops();
     
     if (stops.size() == 0) {
       _tree = null;
+      _refreshService.refresh(RefreshableResources.STOP_GEOSPATIAL_INDEX);
       return;
     }
     
@@ -75,6 +83,8 @@ class WhereGeospatialServiceImpl implements GeospatialBeanService {
     }
 
     _tree.build();
+
+    _refreshService.refresh(RefreshableResources.STOP_GEOSPATIAL_INDEX);
   }
 
   /****

--- a/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/impl/WhereGeospatialServiceImplTest.java
+++ b/onebusaway-transit-data-federation/src/test/java/org/onebusaway/transit_data_federation/impl/WhereGeospatialServiceImplTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.onebusaway.geospatial.model.CoordinateBounds;
 import org.onebusaway.gtfs.model.AgencyAndId;
+import org.onebusaway.container.refresh.RefreshService;
 import org.onebusaway.transit_data_federation.services.transit_graph.StopEntry;
 import org.onebusaway.transit_data_federation.services.transit_graph.TransitGraphDao;
 
@@ -38,6 +39,9 @@ public class WhereGeospatialServiceImplTest {
 
     TransitGraphDao dao = Mockito.mock(TransitGraphDao.class);
     service.setTransitGraphDao(dao);
+
+    RefreshService refreshService = Mockito.mock(RefreshService.class);
+    service.setRefreshService(refreshService);
 
     StopEntry stopA = stop("a", -0.5, -0.5);
     StopEntry stopB = stop("b", -0.5, 0.5);


### PR DESCRIPTION
This corrects an issue which occurs when using the quickstart to build a bundle and run the webapp (in the same execution) such that the spatial index for stops is empty, resulting in no stops showing on the map.

It appears that the dependencies between refreshable resources were backwards in `WhereGeospatialServiceImpl`; it depended on `STOP_GEOSPATIAL_INDEX` and did not itself refresh any resources, whereas it should have depended on `TRANSIT_GRAPH` and refreshed `STOP_GEOSPATIAL_INDEX` (although this refreshable resource is not used anywhere else).

(Possibly the issue reported in https://groups.google.com/d/topic/onebusaway-users/664F4bzpBvA/discussion?)