### PR TITLE
Enable zoom scrolling on map

### DIFF
--- a/onebusaway-presentation/src/main/resources/org/onebusaway/presentation/js/oba-maps.js
+++ b/onebusaway-presentation/src/main/resources/org/onebusaway/presentation/js/oba-maps.js
@@ -186,6 +186,7 @@ var obaMapFactory = function() {
 		var mapOptions = {
 			zoom : zoom,
 			center : mapCenter,
+			gestureHandling: 'greedy',
 			mapTypeId : google.maps.MapTypeId.ROADMAP
 		};
 		


### PR DESCRIPTION
When trying to use the mouse wheel to zoom on the map in the standard interface, the Google Maps API blocks the interaction and instead displays an annoying tip:

![Screenshot of "Use ctrl + scroll to zoom the map"](https://user-images.githubusercontent.com/1888809/35772197-56acd6e0-08ee-11e8-8d39-6adb807064b9.png)

This feature was introduced in to the Google Maps API for maps that are embedded in to a scrollable page to prevent the map from taking control of the user's scrolling action.  This page on OBA will never have any scrolling, so this safety feature is unnecessary.

This feature is detailed in the [`gestureHandling`](https://developers.google.com/maps/documentation/javascript/interaction#gestureHandling) documentation for map options.

PS: I can't quite tell if this JS file is used on other pages with maps (e.g. trip details or vehicle status) or just for the main page.  If it's shared, I'll need some guidance on how to set this option only on specific pages.