### PR TITLE
Override default trip headsign with custom name

### DIFF
--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/StopsForRouteAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/where/StopsForRouteAction.java
@@ -17,7 +17,9 @@ package org.onebusaway.api.actions.api.where;
 
 import org.apache.struts2.rest.DefaultHttpHeaders;
 import org.onebusaway.api.actions.api.ApiActionSupport;
+import org.onebusaway.api.impl.TripsConfigurationServiceClientFileImpl;
 import org.onebusaway.api.model.transit.BeanFactoryV2;
+import org.onebusaway.api.services.TripsConfigurationServiceClient;
 import org.onebusaway.exceptions.ServiceException;
 import org.onebusaway.transit_data.model.StopsForRouteBean;
 import org.onebusaway.transit_data.services.TransitDataService;
@@ -39,6 +41,9 @@ public class StopsForRouteAction extends ApiActionSupport {
   private String _id;
 
   private boolean _includePolylines = true;
+  
+  @Autowired
+  private TripsConfigurationServiceClientFileImpl tConfigurationServiceClientFileImpl;
 
   public StopsForRouteAction() {
     super(LegacyV1ApiSupport.isDefaultToV1() ? V1 : V2);
@@ -65,6 +70,21 @@ public class StopsForRouteAction extends ApiActionSupport {
       return setValidationErrorsResponse();
 
     StopsForRouteBean result = _service.getStopsForRoute(_id);
+    
+    for(int i = 0; i < result.getStopGroupings().size(); i++) {
+    	for(int j = 0; j < result.getStopGroupings().get(i).getStopGroups().size(); j++) {
+    		try {
+				String new_trip = tConfigurationServiceClientFileImpl.getItem("trip", _id, 
+						result.getStopGroupings().get(i).getStopGroups().get(j).getId(), 
+						result.getStopGroupings().get(i).getStopGroups().get(j).getName().getName());
+				if(new_trip != null)
+					result.getStopGroupings().get(i).getStopGroups().get(j).getName().setName(new_trip);
+			} catch (Exception e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			}
+    	}
+    }
 
     if (result == null)
       return setResourceNotFoundResponse();

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/impl/TripsConfigurationServiceClientFileImpl.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/impl/TripsConfigurationServiceClientFileImpl.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2015 Cambridge Systematics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.impl;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.io.FileUtils;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+import org.onebusaway.api.services.TripsConfigurationServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
+
+public class TripsConfigurationServiceClientFileImpl implements
+		TripsConfigurationServiceClient {
+
+	private static Logger _log = LoggerFactory
+			.getLogger(TripsConfigurationServiceClientFileImpl.class);
+	private HashMap<String, Object> _config = null;
+	
+	private boolean isLocal = true;
+	
+	private String configFile = "/var/lib/oba/config.json";
+
+	public void setConfigFile(String file) {
+		_log.info("config service override of configFile=" + file);
+		configFile = file;
+	}
+
+	public TripsConfigurationServiceClientFileImpl() {}
+	
+	public TripsConfigurationServiceClientFileImpl(String configFile) {
+		_log.info("config service using configFile=" + configFile);
+		this.configFile = configFile;
+	}
+	
+	@PostConstruct
+	private void checkConfig(){
+		if(getConfig() == null)
+			isLocal = false;
+	}
+	
+	
+	@Override
+	public URL buildUrl(String baseObject, String... params) throws Exception {
+		// TODO Auto-generated method stub
+		_log.info("empty buildUrl");
+		return null;
+	}
+
+	@Override
+	public void setConfigItem(String baseObject, String component, String key,
+			String value) throws Exception {
+		// TODO Auto-generated method stub
+		_log.info("empty setConfigItem");
+	}
+
+	@Override
+	public String log(String baseObject, String component, Integer priority,
+			String message) {
+		// TODO Auto-generated method stub
+		_log.info("empty log");
+		return null;
+	}
+
+	@Override
+	public List<JsonObject> getItemsForRequest(String baseObject,
+			String... params) throws Exception {
+		// TODO Auto-generated method stub
+		_log.info("empty getItemsForRequest");
+		return null;
+	}
+
+	@Override
+	public List<Map<String, String>> getItems(String baseObject,
+			String... params) throws Exception {
+		_log.debug("getItems(" + baseObject + ", " + params + ")");
+		return (List<Map<String, String>>) getConfig().get("config");
+	}
+
+	@Override
+	public String getItem(String component, String line, String direction, String old_trip) throws Exception {
+		List<Map<String, String>> settings = getItems("config", "list");
+		if (settings == null) return null;
+		for (Map<String, String> setting : settings) {
+		  if (component == null) {
+		    if (setting.containsKey("key") && line.equals(setting.get("line"))) {
+		      _log.debug("getItem(no-component)(" + component  + ", " + line + ")=" + setting.get("new_trip"));
+		      return setting.get("new_trip");  
+		    }
+		  } else {
+			 if ((setting.containsKey("component") && 
+  					component.equals(setting.get("component"))) &&
+  				(setting.containsKey("line") && 
+  					line.equals(setting.get("line"))) &&
+  				(setting.containsKey("direction") && 
+  	  				direction.equals(setting.get("direction")) &&
+  	  			(setting.containsKey("old_trip") && 
+  	    			old_trip.equals(setting.get("old_trip"))))) {
+  			  _log.debug("getItem(" + component  + ", " + line + ")=" + setting.get("new_trip"));
+  				return setting.get("new_trip");
+  			}
+		  }
+		}
+		return null;
+	}
+
+    private HashMap<String, Object> getConfig() {
+		  if (_config != null) {
+			  return _config;
+		  }
+		  
+		    try {
+		        String config = FileUtils.readFileToString(new File(configFile));
+		        HashMap<String, Object> o = new ObjectMapper(new JsonFactory()).readValue(
+		            config, new TypeReference<HashMap<String, Object>>() {
+		            });
+		        _config = o;
+		      } catch (Exception e) {
+		        _log.info("Failed to get configuration out of " + this.configFile + ", continuing without it.", e);
+
+		      }
+		      return _config;
+
+	}
+
+	public boolean isLocal() {
+		return isLocal;
+	}
+	
+}

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/services/TripsConfigurationServiceClient.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/services/TripsConfigurationServiceClient.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 Cambridge Systematics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.api.services;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+
+public interface TripsConfigurationServiceClient {
+
+
+  URL buildUrl(String baseObject, String... params) throws Exception;
+    
+  void setConfigItem(String baseObject, String component, String key, String value) 
+		  throws Exception;
+  
+  String log(String baseObject, String component, Integer priority, String message);
+  
+  List<JsonObject> getItemsForRequest(String baseObject, String... params) throws Exception;
+  
+  /**
+   * Convenience method. Note this assumes all values coming back from the service are strings.
+   */
+  List<Map<String, String>> getItems(String baseObject, String... params) throws Exception;
+  
+  String getItem(String baseObject, String line, String direction, String old_trip) throws Exception;
+  
+  boolean isLocal();
+
+}

--- a/onebusaway-api-webapp/src/main/resources/config_trips.json
+++ b/onebusaway-api-webapp/src/main/resources/config_trips.json
@@ -1,0 +1,6 @@
+{
+ "config":
+ [
+  {"component": "trip", "line": "AGENCY_LINE", "direction": "0", "old_trip": "OldTripName", "new_trip": "NewTripName"}
+ ]
+}

--- a/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/services/TripsConfigurationServiceClient.java
+++ b/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/services/TripsConfigurationServiceClient.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2015 Cambridge Systematics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.enterprise.services;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+import com.google.gson.JsonObject;
+
+public interface TripsConfigurationServiceClient {
+
+
+  URL buildUrl(String baseObject, String... params) throws Exception;
+    
+  void setConfigItem(String baseObject, String component, String key, String value) 
+		  throws Exception;
+  
+  String log(String baseObject, String component, Integer priority, String message);
+  
+  List<JsonObject> getItemsForRequest(String baseObject, String... params) throws Exception;
+  
+  /**
+   * Convenience method. Note this assumes all values coming back from the service are strings.
+   */
+  List<Map<String, String>> getItems(String baseObject, String... params) throws Exception;
+  
+  String getItem(String baseObject, String line, String direction, String old_trip) throws Exception;
+  
+  boolean isLocal();
+
+}

--- a/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/services/impl/TripsConfigurationServiceClientFileImpl.java
+++ b/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/services/impl/TripsConfigurationServiceClientFileImpl.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2015 Cambridge Systematics, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.onebusaway.enterprise.services.impl;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.annotation.PostConstruct;
+
+import org.apache.commons.io.FileUtils;
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.type.TypeReference;
+import org.onebusaway.enterprise.services.TripsConfigurationServiceClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.gson.JsonObject;
+
+public class TripsConfigurationServiceClientFileImpl implements
+		TripsConfigurationServiceClient {
+
+	private static Logger _log = LoggerFactory
+			.getLogger(TripsConfigurationServiceClientFileImpl.class);
+	private HashMap<String, Object> _config = null;
+	
+	private boolean isLocal = true;
+	
+	private String configFile = "/var/lib/oba/config.json";
+
+	public void setConfigFile(String file) {
+		_log.info("config service override of configFile=" + file);
+		configFile = file;
+	}
+
+	public TripsConfigurationServiceClientFileImpl() {}
+	
+	public TripsConfigurationServiceClientFileImpl(String configFile) {
+		_log.info("config service using configFile=" + configFile);
+		this.configFile = configFile;
+	}
+	
+	@PostConstruct
+	private void checkConfig(){
+		if(getConfig() == null)
+			isLocal = false;
+	}
+	
+	
+	@Override
+	public URL buildUrl(String baseObject, String... params) throws Exception {
+		// TODO Auto-generated method stub
+		_log.info("empty buildUrl");
+		return null;
+	}
+
+	@Override
+	public void setConfigItem(String baseObject, String component, String key,
+			String value) throws Exception {
+		// TODO Auto-generated method stub
+		_log.info("empty setConfigItem");
+	}
+
+	@Override
+	public String log(String baseObject, String component, Integer priority,
+			String message) {
+		// TODO Auto-generated method stub
+		_log.info("empty log");
+		return null;
+	}
+
+	@Override
+	public List<JsonObject> getItemsForRequest(String baseObject,
+			String... params) throws Exception {
+		// TODO Auto-generated method stub
+		_log.info("empty getItemsForRequest");
+		return null;
+	}
+
+	@Override
+	public List<Map<String, String>> getItems(String baseObject,
+			String... params) throws Exception {
+		_log.debug("getItems(" + baseObject + ", " + params + ")");
+		return (List<Map<String, String>>) getConfig().get("config");
+	}
+
+	@Override
+	public String getItem(String component, String line, String direction, String old_trip) throws Exception {
+		List<Map<String, String>> settings = getItems("config", "list");
+		if (settings == null) return null;
+		for (Map<String, String> setting : settings) {
+		  if (component == null) {
+		    if (setting.containsKey("key") && line.equals(setting.get("line"))) {
+		      _log.debug("getItem(no-component)(" + component  + ", " + line + ")=" + setting.get("new_trip"));
+		      return setting.get("new_trip");  
+		    }
+		  } else {
+			 if ((setting.containsKey("component") && 
+  					component.equals(setting.get("component"))) &&
+  				(setting.containsKey("line") && 
+  					line.equals(setting.get("line"))) &&
+  				(setting.containsKey("direction") && 
+  	  				direction.equals(setting.get("direction")) &&
+  	  			(setting.containsKey("old_trip") && 
+  	    			old_trip.equals(setting.get("old_trip"))))) {
+  			  _log.debug("getItem(" + component  + ", " + line + ")=" + setting.get("new_trip"));
+  				return setting.get("new_trip");
+  			}
+		  }
+		}
+		return null;
+	}
+
+    private HashMap<String, Object> getConfig() {
+		  if (_config != null) {
+			  return _config;
+		  }
+		  
+		    try {
+		        String config = FileUtils.readFileToString(new File(configFile));
+		        HashMap<String, Object> o = new ObjectMapper(new JsonFactory()).readValue(
+		            config, new TypeReference<HashMap<String, Object>>() {
+		            });
+		        _config = o;
+		      } catch (Exception e) {
+		        _log.info("Failed to get configuration out of " + this.configFile + ", continuing without it.", e);
+
+		      }
+		      return _config;
+
+	}
+
+	public boolean isLocal() {
+		return isLocal;
+	}
+	
+}

--- a/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/webapp/actions/api/SearchAction.java
+++ b/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/webapp/actions/api/SearchAction.java
@@ -21,6 +21,7 @@ import org.onebusaway.presentation.model.SearchResultCollection;
 import org.onebusaway.presentation.services.realtime.RealtimeService;
 import org.onebusaway.presentation.services.search.SearchService;
 import org.onebusaway.transit_data.services.TransitDataService;
+import org.onebusaway.enterprise.services.impl.TripsConfigurationServiceClientFileImpl;
 import org.onebusaway.enterprise.webapp.actions.OneBusAwayEnterpriseActionSupport;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -38,6 +39,9 @@ public class SearchAction extends OneBusAwayEnterpriseActionSupport {
 
   @Autowired
   private RealtimeService _realtimeService;
+  
+  @Autowired
+  private TripsConfigurationServiceClientFileImpl _tConfigurationServiceClientFileImpl
 
   private SearchResultCollection _results = null;
   
@@ -54,7 +58,8 @@ public class SearchAction extends OneBusAwayEnterpriseActionSupport {
     if(_q == null || _q.isEmpty())
       return SUCCESS;
     
-    _results = _searchService.getSearchResults(_q, new SearchResultFactoryImpl(_searchService, _transitDataService, _realtimeService));
+    _results = _searchService.getSearchResults(_q, new SearchResultFactoryImpl(_searchService, _transitDataService, _realtimeService, 
+    		_tConfigurationServiceClientFileImpl));
 
     return SUCCESS;
   }   

--- a/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/webapp/actions/api/SearchResultFactoryImpl.java
+++ b/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/webapp/actions/api/SearchResultFactoryImpl.java
@@ -27,6 +27,8 @@ import org.onebusaway.presentation.services.search.SearchResultFactory;
 import org.onebusaway.presentation.services.search.SearchService;
 import org.onebusaway.transit_data.services.TransitDataService;
 import org.onebusaway.util.SystemTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.onebusaway.enterprise.services.impl.TripsConfigurationServiceClientFileImpl;
 import org.onebusaway.enterprise.webapp.actions.api.model.GeocodeResult;
 import org.onebusaway.enterprise.webapp.actions.api.model.RouteAtStop;
 import org.onebusaway.enterprise.webapp.actions.api.model.RouteDirection;
@@ -47,11 +49,15 @@ public class SearchResultFactoryImpl implements SearchResultFactory {
   private TransitDataService _transitDataService;
 
   private RealtimeService _realtimeService;
+  
+  private TripsConfigurationServiceClientFileImpl _tConfigurationServiceClientFileImpl;
 
-  public SearchResultFactoryImpl(SearchService searchService, TransitDataService transitDataService, RealtimeService realtimeService) {
+  public SearchResultFactoryImpl(SearchService searchService, TransitDataService transitDataService, RealtimeService realtimeService,
+                                TripsConfigurationServiceClientFileImpl tConfigurationServiceClientFileImpl) {
     _searchService = searchService;
     _transitDataService = transitDataService;
     _realtimeService = realtimeService;
+    _tConfigurationServiceClientFileImpl = tConfigurationServiceClientFileImpl;
   }
 
   @Override
@@ -108,7 +114,21 @@ public class SearchResultFactoryImpl implements SearchResultFactory {
         if(routeHasVehiclesInService) {
       	  hasUpcomingScheduledService = true;
         }
-
+        
+        try {
+        	if(routeBean != null) {
+				    String new_trip = _tConfigurationServiceClientFileImpl.getItem("trip", routeBean.getId(), 
+						stopGroupBean.getId(), 
+						stopGroupBean.getName().getName());
+	        	
+				    if(new_trip != null)
+					    stopGroupBean.getName().setName(new_trip);
+        	}
+		    } catch (Exception e) {
+		    	// TODO Auto-generated catch block
+		    	e.printStackTrace();
+	    	}
+        
         directions.add(new RouteDirection(stopGroupBean, polylines, null, hasUpcomingScheduledService));
       }
     }

--- a/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/webapp/actions/api/StopForIdAction.java
+++ b/onebusaway-enterprise-webapp/src/main/java/org/onebusaway/enterprise/webapp/actions/api/StopForIdAction.java
@@ -26,6 +26,7 @@ import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.presentation.impl.service_alerts.ServiceAlertsHelper;
 import org.onebusaway.presentation.services.realtime.RealtimeService;
 import org.onebusaway.transit_data.services.TransitDataService;
+import org.onebusaway.enterprise.services.impl.TripsConfigurationServiceClientFileImpl;
 import org.onebusaway.enterprise.webapp.actions.OneBusAwayEnterpriseActionSupport;
 import org.onebusaway.enterprise.webapp.actions.api.model.RouteAtStop;
 import org.onebusaway.enterprise.webapp.actions.api.model.RouteDirection;
@@ -54,6 +55,9 @@ public class StopForIdAction extends OneBusAwayEnterpriseActionSupport {
 
   @Autowired
   private TransitDataService _transitDataService;
+	
+  @Autowired
+  private TripsConfigurationServiceClientFileImpl tConfigurationServiceClientFileImpl;
 
   private ObjectMapper _mapper = new ObjectMapper();    
 
@@ -114,6 +118,16 @@ public class StopForIdAction extends OneBusAwayEnterpriseActionSupport {
 		          if(routeHasVehiclesInService) {
 		        	  hasUpcomingScheduledService = true;
 		          }
+			  try {
+			    	String new_trip = tConfigurationServiceClientFileImpl.getItem("trip", routeBean.getId(), 
+				stopGroupBean.getId(), 
+				stopGroupBean.getName().getName());
+				if(new_trip != null)
+				  stopGroupBean.getName().setName(new_trip);
+			  } catch (Exception e) {
+				// TODO Auto-generated catch block
+				e.printStackTrace();
+			  }
 		          
 		          routeDirections.add(new RouteDirection(stopGroupBean, null, null, hasUpcomingScheduledService));
 	        }

--- a/onebusaway-sms-webapp/src/main/java/org/onebusaway/sms/impl/SmsArrivalsAndDeparturesModel.java
+++ b/onebusaway-sms-webapp/src/main/java/org/onebusaway/sms/impl/SmsArrivalsAndDeparturesModel.java
@@ -55,11 +55,14 @@ public class SmsArrivalsAndDeparturesModel extends ArrivalsAndDeparturesModel {
   public String getMinutesLabel(ArrivalAndDepartureBean pab) {
     long now = SystemTime.currentTimeMillis();
     long t = pab.getScheduledDepartureTime();
-    if (pab.hasPredictedDepartureTime())
+    boolean isScheduled = true;
+    if (pab.hasPredictedDepartureTime()) {
       t = pab.getPredictedDepartureTime();
+      isScheduled = false;
+    }
     int minutes = (int) Math.round((t - now) / (1000.0 * 60.0));
     boolean isNow = Math.abs(minutes) <= 1;
-    return isNow ? "NOW" : (Integer.toString(minutes) + _minuteLocalization);
+    return isNow ? "NOW"  + (isScheduled ? "*" : ""): (Integer.toString(minutes) + _minuteLocalization) + (isScheduled ? "*" : "");
   }
 
   public String abbreviate(String destination) {


### PR DESCRIPTION
Description:
Mechanism to override default trip headsign to be displayed. Default headsigns for both directions (0 and 1) are selected based on number of trips; in some cases one wants that name to be overwrtitten by custom one.
Example usage scenario:
San Diego MTS has route 10 with most trip headsigns "Univ & I-15” but prefer to display "University & College" instead.
Usage: 
in data-source.xml for api, one should point to config file i.e.:
<bean id="tripsConfigurationServiceClient" class="org.onebusaway.api.impl.TripsConfigurationServiceClientFileImpl" >
<constructor-arg type="java.lang.String" value="E:/OBA/config_trips.json"/>
</bean>
example file is provided in resources.