### PR TITLE
filters out vehicles with >60 mins last update or with no GPS location provided

### DIFF
--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/VehiclePositionsForAgencyAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/VehiclePositionsForAgencyAction.java
@@ -39,6 +39,13 @@ public class VehiclePositionsForAgencyAction extends GtfsRealtimeActionSupport {
 
     ListBean<VehicleStatusBean> vehicles = _service.getAllVehiclesForAgency(
         agencyId, timestamp);
+    
+    //Filter for last vehicle positions < 60'
+    for (int i = vehicles.getList().size() - 1; i >= 0; i--) {
+        if ((((timestamp / 1000) - (vehicles.getList().get(i).getLastUpdateTime() / 1000)) >= 600) || 
+        		vehicles.getList().get(i).getLocation() == null)
+        		vehicles.getList().remove(i);
+    }
 
     for (VehicleStatusBean vehicle : vehicles.getList()) {
       FeedEntity.Builder entity = feed.addEntityBuilder();

--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/VehiclePositionsForAgencyAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/VehiclePositionsForAgencyAction.java
@@ -42,9 +42,9 @@ public class VehiclePositionsForAgencyAction extends GtfsRealtimeActionSupport {
     
     //Filter for last vehicle positions < 60'
     for (int i = vehicles.getList().size() - 1; i >= 0; i--) {
-        if ((((timestamp / 1000) - (vehicles.getList().get(i).getLastUpdateTime() / 1000)) >= 600) || 
-        		vehicles.getList().get(i).getLocation() == null)
-        		vehicles.getList().remove(i);
+      if ((((timestamp / 1000) - (vehicles.getList().get(i).getLastUpdateTime() / 1000)) >= 600) || 
+        vehicles.getList().get(i).getLocation() == null)
+        vehicles.getList().remove(i);
     }
 
     for (VehicleStatusBean vehicle : vehicles.getList()) {


### PR DESCRIPTION
 realtime api filter - that clears information from vehicles, that had their last update > 60 mins ago and those that do not provide location (GPS position).