### PR TITLE
Update Maven repos for OBA and Geotools releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     </repository>
     <repository>
       <id>public.onebusaway.org</id>
-      <url>http://nexus.onebusaway.org/content/groups/public/</url>
+      <url>https://repo.camsys-apps.com/releases/</url>
     </repository>
 
     <!-- Added for Siri V2.0 -->
@@ -61,7 +61,7 @@
   <pluginRepositories>
     <pluginRepository>
       <id>public.onebusaway.org</id>
-      <url>http://nexus.onebusaway.org/content/groups/public/</url>
+      <url>https://repo.camsys-apps.com/releases/</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,11 @@
       <id>public.onebusaway.org</id>
       <url>https://repo.camsys-apps.com/releases/</url>
     </repository>
+    <repository>
+      <id>osgeo</id>
+      <name>Open Source Geospatial Foundation Repository</name>
+      <url>https://repo.osgeo.org/repository/release/</url>
+    </repository>
 
     <!-- Added for Siri V2.0 -->
     <repository>


### PR DESCRIPTION
For GeoTools repo, see https://travis-ci.org/github/OneBusAway/onebusaway-application-modules/builds/677735318, opentripplanner/OpenTripPlanner#3039