### PR TITLE
docs: Update apps list to match README

### DIFF
--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -20,9 +20,15 @@ a variety of interfaces:
     * A text-only version of the web interface for more-basic mobile browsers
 * [OneBusAway REST API](api/where/index.html) - A RESTful web-service that can be used to quickly write applications
 built on top of transit data.  This API powers:
-    * The OneBusAway [iPhone application](https://code.google.com/p/onebusaway/wiki/MobileApp_iPhone)
-    * The OneBusAway [Android application](https://code.google.com/p/seattle-bus-bot/)
-    * The OneBusAway [Windows Phone 7 application](https://onebusawaywp7.codeplex.com) 
+    * [OneBusAway iOS (iPhone)](https://github.com/OneBusAway/onebusaway-ios)
+    * [OneBusAway Android](https://github.com/OneBusAway/onebusaway-android)
+    * [OneBusAway Windows Phone](https://github.com/OneBusAway/onebusaway-windows-phone)
+    * [OneBusAway Windows 8](https://github.com/OneBusAway/onebusaway-windows8)
+    * [OneBusAway Windows 10 (under development)](https://github.com/OneBusAway/onebusaway-windows10)
+    * [OneBusAway Fire Phone (based on Android)](https://github.com/OneBusAway/onebusaway-android)
+    * [OneBusAway Alexa (for Amazon Echo, etc.)](https://github.com/OneBusAway/onebusaway-alexa)
+    * [OneBusAway Glassware (for Google Glass)](https://github.com/OneBusAway/onebusaway-android/pull/219)
+    * [OneBusAway for Pebble Smartwatch](https://github.com/onebusaway/onebusaway-pebbletime)
 * [OneBusAway Phone](features/phone-and-sms.html) - A Interactive Voice Response (IVR) phone application for accessing real-time transit information
 * [OneBusAway SMS](features/phone-and-sms.html) - An SMS service for accessing real-time transit information
 * [OneBusAway Sign Mode](features/sign-mode.html) - A interface mode optimized for large public displays


### PR DESCRIPTION
The list of apps at http://developer.onebusaway.org/modules/onebusaway-application-modules/current/index.html is outdated, including broken links.

I believe this file is the correct place to update the text for the above link.

If so, it should update the above link app list to match the README of the project.