### PR TITLE
Issue #341: When possible, include stop sequence in stop time updates returned by trip-updates-for-agency API endpoint of onebusaway-api-webapp

### DIFF
--- a/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyAction.java
+++ b/onebusaway-api-webapp/src/main/java/org/onebusaway/api/actions/api/gtfs_realtime/TripUpdatesForAgencyAction.java
@@ -76,6 +76,7 @@ public class TripUpdatesForAgencyAction extends GtfsRealtimeActionSupport {
            * to indicate that
            */
           stopTimeUpdate.setStopId(normalizeId(stopId.toString()));
+          stopTimeUpdate.setStopSequence(timepointPrediction.getStopSequence());
           TripUpdate.StopTimeEvent.Builder arrival = stopTimeUpdate.getArrivalBuilder();
           if (timepointPrediction.getTimepointPredictedArrivalTime() != -1) {
             arrival.setTime(timepointPrediction.getTimepointPredictedArrivalTime()/1000L);


### PR DESCRIPTION
See #341 for context. Thanks for your consideration!