### PR TITLE
Fixes Javadoc building process

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/ConsolidatedStopsModificationStrategy.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/ConsolidatedStopsModificationStrategy.java
@@ -15,7 +15,7 @@
  */
 package org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime;
 
-import org.onebusaway.gtfs.model.AgencyAndId;;
+import org.onebusaway.gtfs.model.AgencyAndId;
 import org.onebusaway.transit_data_federation.services.ConsolidatedStopsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
The extra semicolon (`;;`) in the import was breaking `mvn javadoc:javadoc`. This change resolves that issue, allowing the command to run again.