### PR TITLE
Makes the data type of the `User.temporary` column implicit

### DIFF
--- a/onebusaway-users/src/main/java/org/onebusaway/users/model/User.java
+++ b/onebusaway-users/src/main/java/org/onebusaway/users/model/User.java
@@ -103,7 +103,7 @@ public class User extends IdentityBean<Integer> {
 
   private Date lastAccessTime;
 
-  @Column(columnDefinition = "BIT", length = 1)
+  @Column
   private boolean temporary;
 
   @Lob


### PR DESCRIPTION
Fixes https://github.com/OneBusAway/onebusaway-application-modules/issues/352 - `BIT` column type breaks PostgreSQL support

Allow Hibernate to figure out the best column type for a boolean value on its configured database, instead of using a MySQL-only data type.