### PR TITLE
Example config for publishing to Maven Central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -522,16 +522,6 @@
                 <version>3.3</version>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <!--
-                      See discusson above.  We need this here as well for calls to javadoc:javadoc.
-                    -->
-                    <excludePackageNames>com.google.gwt.user.client.ui</excludePackageNames>
-                </configuration>
-            </plugin>
-            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>3.0</version>
@@ -556,6 +546,37 @@
                         <exclude>**/log4j-stdout.xml</exclude>
                     </excludes>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.10.0</version>
+                <configuration>
+                    <doclint>none</doclint>
+                    <failOnError>false</failOnError>
+                    <excludePackageNames>com.google.gwt.user.client.ui</excludePackageNames>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <parent>
-        <artifactId>onebusaway</artifactId>
-        <groupId>org.onebusaway</groupId>
-        <version>1.2.10.1</version>
-    </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>onebusaway-application-modules</artifactId>
+    <groupId>org.onebusaway</groupId>
     <version>2.5.13-otsf</version>
     <packaging>pom</packaging>
 
@@ -100,12 +96,6 @@
     </issueManagement>
 
     <!-- releases and snapshots should be inherited -->
-    <distributionManagement>
-        <site>
-            <id>${site_id}</id>
-            <url>${site_url}</url>
-        </site>
-    </distributionManagement>
     <modules>
         <module>onebusaway-admin-webapp</module>
         <module>onebusaway-agency-metadata</module>
@@ -514,14 +504,8 @@
                     <artifactId>gwt-maven-plugin</artifactId>
                     <version>2.4.0-1-oba</version>
                 </plugin>
-                <plugin>
-                    <!-- disable gpg as its not installed on build server -->
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <configuration>
-                        <skip>true</skip>
-                    </configuration>
-                </plugin>
+
+
             </plugins>
         </pluginManagement>
         <plugins>
@@ -571,6 +555,30 @@
                         <exclude>**/log4j2.xml</exclude>
                         <exclude>**/log4j-stdout.xml</exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.5</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.5.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
This PR adds some example config for publishing to Maven Central.

I'm pleased to say that the publishing process is now a lot more pleasant than it was a few years ago. Sonatype really worked on the DX!

But there are some problems:

### Parent POM

I removed the inheritance from the parent POM because it is defining the distribution repository to be camsys-apps.com but we don't want that. If you want to keep using the parent POM then you'd have to change a few things there.

### Upload limit

The combined upload to Maven Central is 1.5 GB big which is above the size limit: 

![image](https://github.com/user-attachments/assets/749d7247-365a-46b2-b5c2-5364f602c1f1)

https://central.sonatype.org/publish/publish-portal-upload/

I'm not familiar with all these components but there are quite a few *-webapp modules that build large WAR files which are around 200MB each. Are these supposed to be published to Maven Central?

Because of the last point, I haven't actually succeeded in uploading the artifacts.

For reference, this is the command I executed for the deployment: 

```
mvn deploy -DskipTests
```

cc @aaronbrethorst 