### PR TITLE
(feat) Add Metric: last-update-delta (#399)

### DIFF
--- a/onebusaway-watchdog-webapp/src/main/java/org/onebusaway/watchdog/api/realtime/AgencyResource.java
+++ b/onebusaway-watchdog-webapp/src/main/java/org/onebusaway/watchdog/api/realtime/AgencyResource.java
@@ -21,6 +21,8 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime.MonitoredDataSource;
 import org.onebusaway.transit_data_federation.impl.realtime.gtfs_realtime.MonitoredResult;
@@ -52,11 +54,22 @@ public class AgencyResource extends MetricResource {
           }
         }
       }
-      return Response.ok(ok("last-update-delta", (SystemTime.currentTimeMillis() - lastUpdate)/1000)).build();
+
+      long timeSinceLastUpdate = (SystemTime.currentTimeMillis() - lastUpdate) / 1000;
+
+     
+      Map<String, Long> timeSinceLastRealtimeUpdate = new HashMap<>();
+      timeSinceLastRealtimeUpdate.put(agencyId, timeSinceLastUpdate);
+
+      Map<String, Object> responseJson = new HashMap<>();
+      responseJson.put("agenciesWithCoverageCount", 1);
+      responseJson.put("timeSinceLastRealtimeUpdate", timeSinceLastRealtimeUpdate);
+      responseJson.put("scheduledTripsCount", new HashMap<>()); // Placeholder for future data
+
+      return Response.ok(responseJson).build();
     } catch (Exception e) {
       _log.error("getLastUpdateDelta broke", e);
       return Response.ok(error("last-update-delta", e)).build();
     }
   }
-
 }


### PR DESCRIPTION
### Summary:
This pull request introduces a new metric, `timeSinceLastRealtimeUpdate`, to the Metrics API in `AgencyResource.java`. The new field calculates and returns the time (in seconds) since the last successful real-time update for a given agency. This enhancement improves the API’s ability to track real-time data freshness, helping monitor transit updates more effectively.

Resolves issue [#399](https://github.com/OneBusAway/onebusaway-application-modules/issues/397?issue=OneBusAway%7Conebusaway-application-modules%7C399): Add Metric: last-update-delta

### Changes`AgencyResource.java`

**Added `timeSinceLastRealtimeUpdate` field to the API response, structured as:**
```
{
  "agenciesWithCoverageCount": 1,
  "timeSinceLastRealtimeUpdate": { "40": 30 },
  "scheduledTripsCount": {}
}
```