### PR TITLE
feat(metrics): add total records count to MetricsBean (#400)

### DIFF
--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/MetricsBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/MetricsBeanServiceImpl.java
@@ -219,7 +219,7 @@ public class MetricsBeanServiceImpl implements MetricsBeanService {
    * @param bean The MetricsBean object that is populated.
    */
   private void populateTotalRecordsFields(MetricsBean bean) {
-    bean.setRealtimeTripCountsTotal(getTotalRecordsCounts());
+    bean.setRealtimeRecordsTotal(getTotalRecordsCounts());
   }
 
   /**
@@ -238,6 +238,9 @@ public class MetricsBeanServiceImpl implements MetricsBeanService {
 
   /**
    * Retrieves the total record count for the specified agencyId and optional feedId.
+   *
+   * Note: This code was ported over from onebusaway-watchdog-webapp.
+   *
    * @param agencyId The ID of the agency. Required.
    * @param feedId The ID of the feed. Optional.
    * @return The total record count.

--- a/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/MetricsBeanServiceImpl.java
+++ b/onebusaway-transit-data-federation/src/main/java/org/onebusaway/transit_data_federation/impl/beans/MetricsBeanServiceImpl.java
@@ -63,6 +63,9 @@ public class MetricsBeanServiceImpl implements MetricsBeanService {
     populateStopFields(bean);
 
     populateRealtimeTripFields(bean);
+
+    populateTotalRecordsFields(bean);
+
     bean.setScheduledTripsCount(getScheduledTrips());
 
     return bean;
@@ -210,6 +213,50 @@ public class MetricsBeanServiceImpl implements MetricsBeanService {
     bean.setStopIDsUnmatchedCount(getUnmatchedStopIdsCount());
     // add matched stops
     bean.setStopIDsMatchedCount(getMatchedStopIdsCount());
+  }
+  /**
+   * Fills in all total records-related fields in the MetricsBean.
+   * @param bean The MetricsBean object that is populated.
+   */
+  private void populateTotalRecordsFields(MetricsBean bean) {
+    bean.setRealtimeTripCountsTotal(getTotalRecordsCounts());
+  }
+
+  /**
+   * Retrieves a dictionary of agency IDs mapped to the total records count.
+   * @return The per-agency total records count.
+   */
+  private HashMap<String, Integer> getTotalRecordsCounts() {
+    HashMap<String, Integer> totalRecordsCounts = new HashMap<>();
+    for (AgencyWithCoverageBean agency : _transitDataService.getAgenciesWithCoverage()) {
+        String agencyId = agency.getAgency().getId();
+        int totalRecordsCount = getTotalRecordCount(agencyId, null);
+        totalRecordsCounts.put(agencyId, totalRecordsCount);
+    }
+    return totalRecordsCounts;
+  }
+
+  /**
+   * Retrieves the total record count for the specified agencyId and optional feedId.
+   * @param agencyId The ID of the agency. Required.
+   * @param feedId The ID of the feed. Optional.
+   * @return The total record count.
+   */
+  private int getTotalRecordCount(String agencyId, String feedId) {
+    int totalRecords = 0;
+
+    for (MonitoredDataSource mds : getDataSources()) {
+      MonitoredResult result = mds.getMonitoredResult();
+      if (result == null) continue;
+      if (feedId == null || feedId.equals(mds.getFeedId())) {
+        for (String mAgencyId : result.getAgencyIds()) {
+          if (agencyId.equals(mAgencyId)) {
+            totalRecords += result.getRecordsTotal();
+          }
+        }
+      }
+    }
+    return totalRecords;
   }
 
   /**

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/MetricsBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/MetricsBean.java
@@ -33,6 +33,12 @@ public class MetricsBean implements Serializable {
   public HashMap<String, Integer> getScheduledTripsCount() { return scheduledTripsCount; }
   public void setScheduledTripsCount(HashMap<String, Integer> scheduledTripsCount) { this.scheduledTripsCount = scheduledTripsCount; }
 
+  // Realtime Trips Counts Total
+
+  public HashMap<String, Integer> getRealtimeTripCountsTotal() { return realtimeTripCountsTotal; }
+  public void setRealtimeTripCountsTotal(HashMap<String, Integer> realtimeTripCountsTotal) { this.realtimeTripCountsTotal = realtimeTripCountsTotal; }
+  private HashMap<String, Integer> realtimeTripCountsTotal;
+
   // Realtime Trips ids unmatched list
   private HashMap<String, ArrayList<String>> realtimeTripIDsUnmatched;
   public HashMap<String, ArrayList<String>> getRealtimeTripIDsUnmatched() { return realtimeTripIDsUnmatched; }

--- a/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/MetricsBean.java
+++ b/onebusaway-transit-data/src/main/java/org/onebusaway/transit_data/model/MetricsBean.java
@@ -33,11 +33,11 @@ public class MetricsBean implements Serializable {
   public HashMap<String, Integer> getScheduledTripsCount() { return scheduledTripsCount; }
   public void setScheduledTripsCount(HashMap<String, Integer> scheduledTripsCount) { this.scheduledTripsCount = scheduledTripsCount; }
 
-  // Realtime Trips Counts Total
+  // Realtime Records Total
 
-  public HashMap<String, Integer> getRealtimeTripCountsTotal() { return realtimeTripCountsTotal; }
-  public void setRealtimeTripCountsTotal(HashMap<String, Integer> realtimeTripCountsTotal) { this.realtimeTripCountsTotal = realtimeTripCountsTotal; }
-  private HashMap<String, Integer> realtimeTripCountsTotal;
+  public HashMap<String, Integer> getRealtimeRecordsTotal() { return realtimeRecordsTotal; }
+  public void setRealtimeRecordsTotal(HashMap<String, Integer> realtimeRecordsTotal) { this.realtimeRecordsTotal = realtimeRecordsTotal; }
+  private HashMap<String, Integer> realtimeRecordsTotal;
 
   // Realtime Trips ids unmatched list
   private HashMap<String, ArrayList<String>> realtimeTripIDsUnmatched;


### PR DESCRIPTION
### Summary

This pull request adds support for calculating and storing the count of records included in the last real-time update on a per-agency basis in the `MetricsBean`. 

Resolves issue [#400](https://github.com/OneBusAway/onebusaway-application-modules/issues/400): Add Metric: realtime trip total.

### Changes

1. **MetricsBean.java**
   - Added a new field `realtimeRecordsTotal` to store the count of records included in the last real-time update on a per-agency basis.
   - Updated getters and setters for the new field.

2. **MetricsBeanServiceImpl.java**
   - Implemented `populateTotalRecordsFields` method to populate the `realtimeRecordsTotal` field in `MetricsBean`.
   - Added `getTotalRecordsCounts` method to calculate the total records count for each agency.
   - Added `getTotalRecordCount` method to retrieve the total record count for a specified agency and optional feed.
   - Updated `getMetrics` method to include the new metric.
