### PR TITLE
Restore rapid backward scrolling in sign mode

### DIFF
--- a/onebusaway-enterprise-acta-webapp/src/main/webapp/css/sign/jquery.simplyscroll.css
+++ b/onebusaway-enterprise-acta-webapp/src/main/webapp/css/sign/jquery.simplyscroll.css
@@ -176,7 +176,18 @@ Note all DIVs are generated and should not be hard-coded
 	.simply-scroll .simply-scroll-btn-down.disabled {}
 	.simply-scroll .simply-scroll-btn-down:hover {}
 	
-
+	.simply-scroll .simply-scroll-reverse {
+		animation: reverseScroll 0.5s ease-in-out;
+	}
+	
+	@keyframes reverseScroll {
+		0% {
+			transform: translateY(0);
+		}
+		100% {
+			transform: translateY(-100%);
+		}
+	}
 
 /* Vertical scroller example */
 

--- a/onebusaway-enterprise-webapp/src/main/webapp/js/oba/sign/Sign.js
+++ b/onebusaway-enterprise-webapp/src/main/webapp/js/oba/sign/Sign.js
@@ -193,7 +193,7 @@ OBA.Sign = function() {
 	function advance() {
 		var idToDisplay = stopIdsToRequest.shift();
 		stopIdsToRequest.push(idToDisplay);
-		update(idToDisplay);
+		reverseScroll(idToDisplay);
 	}
 
 	function updateClock() {
@@ -817,6 +817,14 @@ OBA.Sign = function() {
 			});
 			
 		}); // ajax()			
+	}
+	
+	function reverseScroll(idToDisplay) {
+		var oldContent = jQuery("#content");
+		var contentWidth = oldContent.width();
+		oldContent.animate({left: -contentWidth}, 500, function() {
+			update(idToDisplay);
+		});
 	}
 	
 	return {

--- a/onebusaway-frontend-webapp/src/main/webapp/WEB-INF/content/sign/sign.jspx
+++ b/onebusaway-frontend-webapp/src/main/webapp/WEB-INF/content/sign/sign.jspx
@@ -46,7 +46,7 @@
 	</s:url>
 	<script type="text/javascript" src="${url}"><!-- //prevent jspx minimization --></script>
 
-	<s:url var="url" value="/js/biblio/jquery-migrate-3.4.1.js">
+	<s:url var="url" value="/js/biblio/jquery.migrate-3.4.1.js">
 		<s:param name="v"><s:property value="frontEndVersion" /></s:param>
 	</s:url>
 	<script type="text/javascript" src="${url}"><!-- //prevent jspx minimization --></script>
@@ -74,6 +74,16 @@
 	<s:url var="url" value="/js/oba/sign/Sign.js">
 		<s:param name="v"><s:property value="frontEndVersion" /></s:param>
   	</s:url>
+	<script type="text/javascript" src="${url}"><!-- //prevent jspx minimization --></script>
+
+	<s:url var="url" value="/css/sign/reverseScroll.css">
+		<s:param name="v"><s:property value="frontEndVersion" /></s:param>
+	</s:url>
+	<link rel="stylesheet" href="${url}" type="text/css" media="screen"/>
+
+	<s:url var="url" value="/js/biblio/reverseScroll.js">
+		<s:param name="v"><s:property value="frontEndVersion" /></s:param>
+	</s:url>
 	<script type="text/javascript" src="${url}"><!-- //prevent jspx minimization --></script>
 </head>
 <body>


### PR DESCRIPTION
Fixes #431

Add rapid reverse scroll effect to Sign Mode.

* Modify `onebusaway-enterprise-webapp/src/main/webapp/js/oba/sign/Sign.js` to include a new `reverseScroll` function and update the `advance` function to call `reverseScroll` before resetting the scroll position.
* Update `onebusaway-enterprise-acta-webapp/src/main/webapp/css/sign/jquery.simplyscroll.css` to add CSS rules and keyframes for the `reverseScroll` effect.
* Modify `onebusaway-frontend-webapp/src/main/webapp/WEB-INF/content/sign/sign.jspx` to include the necessary JavaScript and CSS files for the `reverseScroll` effect.

