### PR TITLE
Fix missing maven-shade-plugin version warning

### DIFF
--- a/onebusaway-api-key-cli/pom.xml
+++ b/onebusaway-api-key-cli/pom.xml
@@ -81,7 +81,9 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
+                <version>${maven-shade-plugin-version}</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
Add explicit groupId and version to maven-shade-plugin in
onebusaway-api-key-cli/pom.xml to resolve Maven warning about
missing 'build.plugins.plugin.version'.

Uses ${maven-shade-plugin-version} property (3.6.0) defined in
parent pom, consistent with other modules like
onebusaway-transit-data-federation-builder.