### PR TITLE
Fix CLI-created API keys returning 401 permission denied

### DIFF
--- a/onebusaway-api-key-cli/src/main/java/org/onebusaway/cli/apikey/ApiKeyCliMain.java
+++ b/onebusaway-api-key-cli/src/main/java/org/onebusaway/cli/apikey/ApiKeyCliMain.java
@@ -284,7 +284,7 @@ public class ApiKeyCliMain {
         }
 
         // Create the key
-        UserIndex userIndex = userService.getOrCreateUserForIndexKey(indexKey, "", true);
+        UserIndex userIndex = userService.getOrCreateUserForIndexKey(indexKey, keyValue, false);
         userPropertiesService.authorizeApi(userIndex.getUser(), minApiReqInt);
 
         User user = userIndex.getUser();

--- a/onebusaway-api-key-cli/src/test/java/org/onebusaway/cli/apikey/ApiKeyCliMainTest.java
+++ b/onebusaway-api-key-cli/src/test/java/org/onebusaway/cli/apikey/ApiKeyCliMainTest.java
@@ -249,12 +249,12 @@ public class ApiKeyCliMainTest {
         User mockUser = mockUserIndex.getUser();
 
         when(userService.getUserIndexForId(any(UserIndexKey.class))).thenReturn(null);
-        when(userService.getOrCreateUserForIndexKey(any(UserIndexKey.class), eq(""), eq(true)))
+        when(userService.getOrCreateUserForIndexKey(any(UserIndexKey.class), eq("test-key-123"), eq(false)))
             .thenReturn(mockUserIndex);
 
         cli.run(new String[]{"create", "--config", "/tmp/data-sources.xml", "--key", keyValue});
 
-        verify(userService).getOrCreateUserForIndexKey(any(UserIndexKey.class), eq(""), eq(true));
+        verify(userService).getOrCreateUserForIndexKey(any(UserIndexKey.class), eq("test-key-123"), eq(false));
         verify(userPropertiesService).authorizeApi(eq(mockUser), anyLong());
         verify(userPropertiesService).updateApiKeyContactInfo(eq(mockUser), anyString(), anyString(), anyString(), anyString());
         assertTrue(outContent.toString().contains("API key created successfully"));
@@ -267,7 +267,7 @@ public class ApiKeyCliMainTest {
         User mockUser = mockUserIndex.getUser();
 
         when(userService.getUserIndexForId(any(UserIndexKey.class))).thenReturn(null);
-        when(userService.getOrCreateUserForIndexKey(any(UserIndexKey.class), eq(""), eq(true)))
+        when(userService.getOrCreateUserForIndexKey(any(UserIndexKey.class), eq("test-key-456"), eq(false)))
             .thenReturn(mockUserIndex);
 
         cli.run(new String[]{
@@ -515,7 +515,7 @@ public class ApiKeyCliMainTest {
         User mockUser = mockUserIndex.getUser();
 
         when(userService.getUserIndexForId(any(UserIndexKey.class))).thenReturn(null);
-        when(userService.getOrCreateUserForIndexKey(any(UserIndexKey.class), eq(""), eq(true)))
+        when(userService.getOrCreateUserForIndexKey(any(UserIndexKey.class), eq("json-test-key"), eq(false)))
             .thenReturn(mockUserIndex);
 
         cli.run(new String[]{


### PR DESCRIPTION
## Summary

- Fix `doCreate()` in `ApiKeyCliMain` passing incorrect arguments to `getOrCreateUserForIndexKey()`: empty string for credentials and `true` for `isAnonymous`, causing keys to be created with `ROLE_ANONYMOUS` instead of `ROLE_USER`
- Pass the actual key value and `false` to match the working pattern in `CreateApiKeyAction`
- Update test mock expectations to verify the corrected arguments

Fixes #455

## Test plan

- [x] All 48 tests in `onebusaway-api-key-cli` pass
- [ ] Create an API key via CLI and verify it returns 200 instead of 401 against the API