### PR TITLE
Speed up gtfs-rt integration tests: cache bundle builds + parallel forks

### DIFF
--- a/onebusaway-gtfsrt-integration-tests/pom.xml
+++ b/onebusaway-gtfsrt-integration-tests/pom.xml
@@ -12,6 +12,15 @@
 
   <name>onebusaway-gtfsrt-integration-tests</name>
 
+  <properties>
+    <!-- Number of parallel JVMs used to run these integration tests. Each fork
+         loads a full transit bundle into memory, so this trades memory for
+         wall-clock time. 2 is a safe default for a typical CI runner; raise it
+         (e.g. -Dintegration.forkCount=4 or a per-core multiplier like 1C) only
+         on hosts with spare memory, and drop to 1 if forks run out of memory. -->
+    <integration.forkCount>2</integration.forkCount>
+  </properties>
+
   <dependencies>
 
     <!--       Log4j 2 -->
@@ -133,5 +142,25 @@
     </dependency>
 
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <!-- The integration tests are independent per class; run them in
+               parallel JVMs to use the available CI cores. reuseForks lets the
+               per-JVM bundle cache (see AbstractGtfsRealtimeIntegrationTest)
+               be shared across classes that use the same dataset within a fork.
+               Do NOT add <parallel>methods</parallel> / threadCount here: the
+               bundle cache and the per-method global system properties set in
+               BundleLoader assume methods run sequentially within a fork. -->
+          <forkCount>${integration.forkCount}</forkCount>
+          <reuseForks>true</reuseForks>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/onebusaway-gtfsrt-integration-tests/src/test/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/AbstractGtfsRealtimeIntegrationTest.java
+++ b/onebusaway-gtfsrt-integration-tests/src/test/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/AbstractGtfsRealtimeIntegrationTest.java
@@ -55,6 +55,29 @@ public abstract class AbstractGtfsRealtimeIntegrationTest {
 
   protected static Logger _log = LoggerFactory.getLogger(AbstractGtfsRealtimeIntegrationTest.class);
 
+  /**
+   * Building the GTFS bundle (parsing GTFS into the transit graph) is by far the
+   * most expensive part of these tests, and the result is an immutable bundle on
+   * disk. We therefore build each dataset at most once per JVM and reuse it,
+   * keyed by integration-test path. Multiple test classes (and, for
+   * NyctRandomIntegrationTest, multiple methods) share the same dataset, so this
+   * eliminates the bulk of the redundant work.
+   *
+   * <p>Note: only the on-disk bundle is shared. A fresh Spring context and
+   * {@link GtfsRealtimeSource} are still created per test method (see
+   * {@link #setup()}) because realtime state -- route cancellations in the cancel
+   * service and added/dynamic blocks in the dynamic block index -- accumulates in
+   * singleton beans within each per-method Spring context and must not leak
+   * between methods.
+   *
+   * <p>The map holds only the lightweight {@link BundleContext} (a few on-disk
+   * paths) and is never evicted, which is fine for a test JVM. This complements
+   * {@link BundleBuilder}'s cross-run, env-var-driven reuse ({@code bundle.keep}
+   * / {@code bundle.index.json}); here we dedupe builds automatically within a
+   * single run, across datasets and classes.
+   */
+  private static final Map<String, BundleContext> BUILT_BUNDLES = new HashMap<>();
+
   private BundleContext _bundleContext;
   protected BundleContext getBundleContext() {
     return _bundleContext;
@@ -62,11 +85,6 @@ public abstract class AbstractGtfsRealtimeIntegrationTest {
   private BundleLoader _bundleLoader;
   public BundleLoader getBundleLoader() {
     return _bundleLoader;
-  }
-
-  private BundleBuilder _bundleBuilder;
-  public BundleBuilder getBundleBuilder() {
-    return _bundleBuilder;
   }
 
   protected Map<AgencyAndId, Set<String>> stopHeadsigns = new HashMap<>();
@@ -80,10 +98,19 @@ public abstract class AbstractGtfsRealtimeIntegrationTest {
   protected List<String> _exceptionRouteIds = Arrays.asList("MTASBWY_M");
   @Before
   public void setup() throws Exception {
-    _bundleBuilder = new BundleBuilder();
-    _bundleBuilder.setup(getIntegrationTestPath());
-    _bundleContext = _bundleBuilder.getBundleContext();
+    // Build the dataset once per JVM (see BUILT_BUNDLES), reusing it for later
+    // methods/classes that share the same dataset. No locking needed: surefire
+    // forks are separate JVMs and methods within a fork run sequentially.
+    String path = getIntegrationTestPath();
+    _bundleContext = BUILT_BUNDLES.get(path);
+    if (_bundleContext == null) {
+      BundleBuilder builder = new BundleBuilder();
+      builder.setup(path);
+      _bundleContext = builder.getBundleContext();
+      BUILT_BUNDLES.put(path, _bundleContext);
+    }
 
+    // A fresh context + source per method keeps realtime state isolated.
     _bundleLoader = new BundleLoader(_bundleContext);
     _bundleLoader.create(getPaths());
     _bundleLoader.load();

--- a/onebusaway-gtfsrt-integration-tests/src/test/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/BundleBuilder.java
+++ b/onebusaway-gtfsrt-integration-tests/src/test/java/org/onebusaway/transit_data_federation/impl/realtime/gtfs_realtime/BundleBuilder.java
@@ -24,11 +24,17 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Support for building bundles in integration tests.
  */
 public class BundleBuilder {
+
+  // Distinguishes bundle output directories across builds within one JVM;
+  // combined with the process id (see buildBundle) it keeps parallel surefire
+  // forks from colliding on a shared temp directory.
+  private static final AtomicInteger BUNDLE_SEQ = new AtomicInteger();
 
   private BundleContext _bundleContext = new BundleContext();
 
@@ -52,12 +58,16 @@ public class BundleBuilder {
   public void buildBundle(String bundlePath) throws Exception {
     ClassPathResource bundleResource = new ClassPathResource(bundlePath);
     String bundleInputDir = bundleResource.getURL().getFile();
+    // Unique across parallel forks (pid) and across builds within a fork (seq)
+    // so concurrent JVMs never write into the same bundle directory. A bare
+    // timestamp is not enough: two forks can build in the same millisecond.
+    String uniqueId = ProcessHandle.current().pid() + "-" + BUNDLE_SEQ.incrementAndGet();
     String bundleRootDir =
             addSlash(System.getProperty("java.io.tmpdir"))
-                    + "bundle" + System.currentTimeMillis();
+                    + "bundle" + uniqueId;
     makeTempDirectory(bundleRootDir, System.getProperty("bundle.keep"));
 
-    String bundleName = "v" + System.currentTimeMillis();
+    String bundleName = "v" + uniqueId;
     String bundleGzipURI = buildBundle(bundleInputDir, bundleRootDir, bundleName);
     String bundleIndexURI = bundleRootDir + File.separator + "index.json";
     _bundleContext.setup(bundleRootDir, bundleGzipURI, bundleIndexURI);


### PR DESCRIPTION
## Summary

The `onebusaway-gtfsrt-integration-tests` module was the dominant cost in CI — **~13:51 of an ~18 min job**, and the source of ~67k log lines. Two causes: `AbstractGtfsRealtimeIntegrationTest`'s `@Before` rebuilt the full GTFS transit-graph bundle (the expensive part) before *every* test method, and the suite ran serially.

- **Build each dataset's bundle once per JVM**, cached by integration-test path (`BUILT_BUNDLES`). Multiple classes share a dataset (`nyct_wrong_way`, `st_duplicated_trips`, …), and all of `NyctRandomIntegrationTest`'s active methods share one — so this removes the bulk of redundant builds. Only the immutable on-disk bundle is shared; a **fresh Spring context + `GtfsRealtimeSource` is still created per method**, so realtime state that accumulates in context singletons (route cancellations, dynamic/added blocks) stays isolated.
- **Run test classes in parallel JVMs** via surefire `forkCount=2` + `reuseForks=true` (overridable with `-Dintegration.forkCount`).
- **Make each bundle build's temp dir process-unique** (pid + counter) so parallel forks can't collide on a same-millisecond timestamp.

Local results (this module): test time **~13:51 → ~4:20**, bundle builds **12 → 5**, no OOM at `forkCount=2`.

## Test plan

- [x] Full module green via `mvn test -pl onebusaway-gtfsrt-integration-tests -am`: 15 classes, **0 failures / 0 errors**, same skip pattern as the prior CI run
- [x] `NyctRandomIntegrationTest` builds the bundle **once** instead of 5×, all 5 active methods still pass (370s → 254s)
- [x] No `OutOfMemoryError` with `forkCount=2`
- [x] Re-verified green after code-review fixes (refactor + `BundleBuilder` uniqueness + pom)
- [ ] **CI to confirm on the real runner:** memory headroom at `forkCount=2` on the standard 4-core/16 GB runner, and end-to-end job wall-clock

## Review notes (non-blocking)

- **Runner memory is the main unknown** — `forkCount=2` × full transit bundle was only validated on a dev machine. If CI OOMs, set `-Dintegration.forkCount=1` (the property is wired for exactly this).
- The parallel-fork temp-dir fix is structurally sound (process-unique paths) rather than empirically race-reproduced.
- Reuse note: this in-run cache complements `BundleBuilder`'s existing manual cross-run reuse (`bundle.keep` / `bundle.index.json`); they were left as separate mechanisms rather than unified, to keep the change scoped.
- Not addressed here: the ~67k-line log spew. It's mostly INFO from bundle builds (now deduplicated) and is **marginal for time**; a proper fix requires untangling the runtime log4j2 reconfiguration triggered by the workflow's `-Dlog4j.configuration=` flag, which is out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration test parallelization with optimized configuration.
  * Improved test bundle caching to reduce redundant processing across test runs.
  * Reduced risk of directory collision issues during parallel test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->